### PR TITLE
fix(version): clarify default sentinel values in package doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
  <strong>An opinionated Claude Code configuration that trades narrative for signal.</strong>
 </p>
 
-
 <p align="center">
  <a href="docs/guides/install.md">Install</a> &bull;
  <a href="docs/reference/concepts.md">Concepts</a> &bull;

--- a/atomic/internal/version/version.go
+++ b/atomic/internal/version/version.go
@@ -1,6 +1,6 @@
 // Package version exposes the binary version and commit SHA.
-// Both values default to sentinel strings and can be overridden at build time
-// via -ldflags:
+// Both default to "dev" / "unknown" and are overridden at build time via
+// -ldflags:
 //
 //	go build -ldflags "-X github.com/damusix/atomic-claude/atomic/internal/version.Version=v0.1.0 \
 //	                   -X github.com/damusix/atomic-claude/atomic/internal/version.Commit=abc1234" \


### PR DESCRIPTION
The prior fix commit (c0bcfad) only touched README.md at the repo root, which release-please ignores because the package path is scoped to atomic/. This commit touches atomic/ so release-please associates it with the Go module and creates the patch release PR for the prompt alignment refactor (4011b30).