### PR TITLE
fix: skip bundle/manifest checks outside the atomic-claude repo

### DIFF
--- a/atomic/internal/doctor/doctor.go
+++ b/atomic/internal/doctor/doctor.go
@@ -2,6 +2,8 @@
 // integrity check for atomic-claude install + project state coherence.
 package doctor
 
+import "os"
+
 // Severity represents the outcome of a single check.
 type Severity string
 
@@ -45,6 +47,14 @@ type Category struct {
 	Name     string
 	Severity Severity // default severity for this category (individual Results may override)
 	Run      CheckFunc
+
+	// RepoDevOnly marks a check that only makes sense inside the atomic-claude
+	// development repo (e.g. manifest parity against the embedded source
+	// snapshot). Outside that repo it is omitted entirely — not even a SKIP
+	// line — so end users running atomic doctor in their own projects never see
+	// repo-development noise. An explicit `--only <index>` request overrides
+	// this and runs the check anyway (it self-reports SKIP).
+	RepoDevOnly bool
 }
 
 // categories is the single source of truth for all check categories.
@@ -55,7 +65,7 @@ var categories = []Category{
 	{Index: 2, Name: "hooks", Severity: WARN, Run: checkHooks},
 	{Index: 3, Name: "signals", Severity: WARN, Run: checkSignals},
 	{Index: 4, Name: "refs", Severity: FAIL, Run: checkRefs},
-	{Index: 5, Name: "manifest", Severity: FAIL, Run: checkManifest},
+	{Index: 5, Name: "manifest", Severity: FAIL, Run: checkManifest, RepoDevOnly: true},
 	{Index: 6, Name: "followups", Severity: WARN, Run: checkFollowups},
 	{Index: 7, Name: "memory", Severity: WARN, Run: checkMemory},
 	{Index: 8, Name: "binary", Severity: WARN, Run: checkBinary},
@@ -69,8 +79,15 @@ func Categories() []Category {
 }
 
 // Run executes the full registry (or the filtered subset in opts) and returns
-// results in index order.
+// results in index order. Repo-dev-only checks are auto-omitted outside the
+// atomic-claude repo (detected from cwd) unless explicitly requested via --only.
 func Run(opts Opts) ([]Result, error) {
+	return RunWith(opts, isRepoDevCwd())
+}
+
+// RunWith is Run with the repo-dev verdict injected, exported for testing so a
+// repo-dev / non-repo-dev tree can be simulated without chdir.
+func RunWith(opts Opts, repoDev bool) ([]Result, error) {
 	onlySet := indexSet(opts.Only)
 	skipSet := indexSet(opts.Skip)
 
@@ -83,12 +100,32 @@ func Run(opts Opts) ([]Result, error) {
 		if skipSet[c.Index] {
 			continue
 		}
+		// Repo-dev-only checks are noise outside the atomic-claude repo. Omit
+		// them entirely unless the user explicitly asked via --only.
+		if c.RepoDevOnly && !repoDev && !onlySet[c.Index] {
+			continue
+		}
 		r := c.Run(opts)
 		r.Index = c.Index
 		r.Name = c.Name
 		results = append(results, r)
 	}
 	return results, nil
+}
+
+// isRepoDevCwd reports whether the current working directory is inside the
+// atomic-claude development repo. Best-effort: a getwd or detection error
+// resolves to false (treat as a normal user repo).
+func isRepoDevCwd() bool {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+	ok, err := IsRepoDev(cwd)
+	if err != nil {
+		return false
+	}
+	return ok
 }
 
 // indexSet converts a slice of indices to a presence map for O(1) lookup.

--- a/atomic/internal/doctor/run_repodev_test.go
+++ b/atomic/internal/doctor/run_repodev_test.go
@@ -1,0 +1,55 @@
+package doctor_test
+
+import (
+	"testing"
+
+	"github.com/damusix/atomic-claude/atomic/internal/doctor"
+)
+
+// hasIndex reports whether results contain a check with the given category index.
+func hasIndex(results []doctor.Result, idx int) bool {
+	for _, r := range results {
+		if r.Index == idx {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRunWith_NotRepoDev_OmitsManifest proves that outside the atomic-claude
+// repo, the manifest check (category 5, RepoDevOnly) is omitted entirely — no
+// result row, not even a SKIP. End users never see repo-dev noise.
+func TestRunWith_NotRepoDev_OmitsManifest(t *testing.T) {
+	results, err := doctor.RunWith(doctor.Opts{}, false)
+	if err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if hasIndex(results, 5) {
+		t.Errorf("manifest check (index 5) must be omitted outside atomic-claude repo, but it is present")
+	}
+}
+
+// TestRunWith_RepoDev_IncludesManifest proves the manifest check IS present when
+// running inside the atomic-claude repo.
+func TestRunWith_RepoDev_IncludesManifest(t *testing.T) {
+	results, err := doctor.RunWith(doctor.Opts{}, true)
+	if err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if !hasIndex(results, 5) {
+		t.Errorf("manifest check (index 5) must be present inside atomic-claude repo, but it is omitted")
+	}
+}
+
+// TestRunWith_NotRepoDev_ExplicitOnlyRunsManifest proves an explicit
+// `--only 5` request runs the manifest check even outside the repo (it then
+// self-reports SKIP). Explicit intent overrides the auto-omit.
+func TestRunWith_NotRepoDev_ExplicitOnlyRunsManifest(t *testing.T) {
+	results, err := doctor.RunWith(doctor.Opts{Only: []int{5}}, false)
+	if err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if !hasIndex(results, 5) {
+		t.Errorf("explicit --only 5 must run manifest check even outside the repo")
+	}
+}

--- a/atomic/internal/validate/bundle.go
+++ b/atomic/internal/validate/bundle.go
@@ -91,12 +91,9 @@ func runBundleImpl(jsonOut, suggest bool, w io.Writer) int {
 		return 2
 	}
 
+	// repoRoot may be "" outside a git repo; runBundleAt skips cleanly when the
+	// tree is not the atomic-claude dev repo, so no .git error is raised here.
 	repoRoot := findRepoRoot(cwd)
-	if repoRoot == "" {
-		fmt.Fprintf(w, "atomic validate bundle: no .git found from %s\n", cwd)
-		return 2
-	}
-
 	return runBundleAt(repoRoot, jsonOut, suggest, w)
 }
 
@@ -104,7 +101,22 @@ func runBundleImpl(jsonOut, suggest bool, w io.Writer) int {
 // manifestcheck.Compare (shared with atomic doctor). Drift entries are
 // converted to Findings with Rule="bundle" and Severity="FAIL", emitted via
 // the unified formatter so all three subcommands share one output contract.
+//
+// Bundle parity only has meaning in the atomic-claude dev repo (it compares the
+// working tree against the embedded source snapshot). When repoRoot is not that
+// repo, the check is skipped cleanly with exit 0 rather than crashing on the
+// absent source (issue #35).
 func runBundleAt(repoRoot string, jsonOut, suggest bool, w io.Writer) int {
+	if !repoDev(repoRoot) {
+		if jsonOut {
+			printJSON(w, nil, summary{})
+		} else {
+			printHeader(w, "bundle", "manifest parity")
+			fmt.Fprintln(w, "SKIP — not in atomic-claude repo (no embedded source to compare)")
+		}
+		return 0
+	}
+
 	findings, exit := bundleFindings(repoRoot)
 	if exit != 0 {
 		fmt.Fprintf(w, "atomic validate bundle: internal error\n")

--- a/atomic/internal/validate/dispatch.go
+++ b/atomic/internal/validate/dispatch.go
@@ -178,12 +178,21 @@ func runWholeRepo(jsonOut, suggest bool, w io.Writer) int {
 	}
 	configSummary := summarize(configFindings)
 
-	// --- Bundle ---
-	// Capture bundle output separately so we can aggregate findings.
-	bundleFindings, bundleSummary, bundleErr := runBundleCollect(root)
-	if bundleErr != 0 {
-		fmt.Fprintf(w, "atomic validate: bundle check failed: internal error (exit %d)\n", bundleErr)
-		return 2
+	// --- Bundle (repo-dev only) ---
+	// Bundle parity compares the working tree against the embedded source
+	// snapshot, which only exists in the atomic-claude repo. Outside it, skip
+	// silently — a user's own project has no bundle to validate, and surfacing
+	// it would crash (issue #35) or confuse.
+	var bundleFindings []Finding
+	var bundleSummary summary
+	includeBundle := repoDev(root)
+	if includeBundle {
+		var bundleErr int
+		bundleFindings, bundleSummary, bundleErr = runBundleCollect(root)
+		if bundleErr != 0 {
+			fmt.Fprintf(w, "atomic validate: bundle check failed: internal error (exit %d)\n", bundleErr)
+			return 2
+		}
 	}
 
 	// --- Aggregate ---
@@ -213,10 +222,11 @@ func runWholeRepo(jsonOut, suggest bool, w io.Writer) int {
 	printHeader(w, "config", "referential integrity")
 	printHuman(w, configFindings, configSummary, suggest)
 
-	fmt.Fprintln(w)
-
-	printHeader(w, "bundle", "manifest parity")
-	printHuman(w, bundleFindings, bundleSummary, suggest)
+	if includeBundle {
+		fmt.Fprintln(w)
+		printHeader(w, "bundle", "manifest parity")
+		printHuman(w, bundleFindings, bundleSummary, suggest)
+	}
 
 	return exitCode(aggSummary)
 }

--- a/atomic/internal/validate/dispatch_test.go
+++ b/atomic/internal/validate/dispatch_test.go
@@ -78,6 +78,20 @@ Minimal config for test.
 	return root
 }
 
+// addRepoDevMarker creates the bundle-mirror source file that identifies a tree
+// as the atomic-claude development repo. Bundle parity only runs when this
+// marker is present.
+func addRepoDevMarker(t *testing.T, root string) {
+	t.Helper()
+	dir := filepath.Join(root, "atomic", "internal", "bundlemirror")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir bundlemirror: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mirror.go"), []byte("package bundlemirror\n"), 0o644); err != nil {
+		t.Fatalf("write mirror.go: %v", err)
+	}
+}
+
 // runFromDir temporarily sets the working directory and calls RunWithOutput,
 // then restores the original wd. This is needed so findRepoRoot works correctly.
 func runFromDir(t *testing.T, dir string, args []string) (code int, out string) {
@@ -110,9 +124,9 @@ func runFromDir(t *testing.T, dir string, args []string) (code int, out string) 
 // output. Exit 0 or 1 both indicate validators ran; exit 2 means the dispatch
 // itself failed (internal error), which must not happen on a valid repo.
 //
-// Note: the synthetic repo has no real bundle artifacts, so bundle parity
-// will FAIL (exit 1 is expected). The test checks that all three sections ran,
-// not that everything passed.
+// Note: a minimal repo is NOT the atomic-claude dev repo (no bundle-mirror
+// marker), so the bundle validator is skipped silently — spec + config run and
+// the bundle header must NOT appear.
 func TestDispatch_WholeRepo_Exit0(t *testing.T) {
 	root := buildMinimalRepo(t)
 	code, out := runFromDir(t, root, []string{})
@@ -122,11 +136,61 @@ func TestDispatch_WholeRepo_Exit0(t *testing.T) {
 		t.Errorf("whole-repo on minimal repo: got internal error (exit 2)\noutput:\n%s", out)
 	}
 
-	// Each subcommand header must appear — proving all three validators ran.
-	for _, header := range []string{"atomic validate spec", "atomic validate config", "atomic validate bundle"} {
+	// spec + config run anywhere.
+	for _, header := range []string{"atomic validate spec", "atomic validate config"} {
 		if !strings.Contains(out, header) {
 			t.Errorf("whole-repo output missing header %q:\n%s", header, out)
 		}
+	}
+	// bundle is repo-dev-only: must be skipped outside the atomic-claude repo.
+	if strings.Contains(out, "atomic validate bundle") {
+		t.Errorf("whole-repo outside atomic-claude repo must skip bundle, but bundle header present:\n%s", out)
+	}
+}
+
+// TestDispatch_WholeRepo_RepoDev_IncludesBundle proves the bundle validator
+// runs (header present) when the tree IS the atomic-claude dev repo.
+func TestDispatch_WholeRepo_RepoDev_IncludesBundle(t *testing.T) {
+	root := buildMinimalRepo(t)
+	addRepoDevMarker(t, root)
+	code, out := runFromDir(t, root, []string{})
+
+	if code == 2 {
+		t.Errorf("whole-repo on repo-dev tree: got internal error (exit 2)\noutput:\n%s", out)
+	}
+	for _, header := range []string{"atomic validate spec", "atomic validate config", "atomic validate bundle"} {
+		if !strings.Contains(out, header) {
+			t.Errorf("repo-dev whole-repo output missing header %q:\n%s", header, out)
+		}
+	}
+}
+
+// TestDispatch_Bundle_NotRepoDev_Skips proves explicit `atomic validate bundle`
+// outside the atomic-claude repo exits 0 with a clean SKIP, not a crash (exit 2).
+// Regression for issue #35.
+func TestDispatch_Bundle_NotRepoDev_Skips(t *testing.T) {
+	root := buildMinimalRepo(t)
+	code, out := runFromDir(t, root, []string{"bundle"})
+
+	if code != 0 {
+		t.Errorf("explicit bundle outside atomic-claude repo: got exit %d, want 0\noutput:\n%s", code, out)
+	}
+	if !strings.Contains(out, "SKIP") {
+		t.Errorf("explicit bundle skip should mention SKIP:\n%s", out)
+	}
+}
+
+// TestDispatch_Bundle_NotRepoDev_JSON proves the JSON path also skips cleanly
+// (exit 0, valid envelope, no internal error) outside the repo.
+func TestDispatch_Bundle_NotRepoDev_JSON(t *testing.T) {
+	root := buildMinimalRepo(t)
+	code, out := runFromDir(t, root, []string{"--json", "bundle"})
+
+	if code != 0 {
+		t.Errorf("explicit bundle --json outside repo: got exit %d, want 0\noutput:\n%s", code, out)
+	}
+	if !strings.Contains(out, "schema_version") {
+		t.Errorf("bundle --json skip missing schema_version:\n%s", out)
 	}
 }
 

--- a/atomic/internal/validate/repo.go
+++ b/atomic/internal/validate/repo.go
@@ -26,3 +26,18 @@ func findRepoRoot(startDir string) string {
 		dir = parent
 	}
 }
+
+// repoDev reports whether root is the atomic-claude development repo, detected
+// by the presence of the bundle-mirror source that only exists in-repo. The
+// bundle-parity check compares the working tree against the embedded source
+// snapshot, which has no meaning outside this repo, so callers skip it when
+// this returns false. Mirrors doctor.IsRepoDev's marker heuristic without
+// importing the doctor package.
+func repoDev(root string) bool {
+	if root == "" {
+		return false
+	}
+	marker := filepath.Join(root, "atomic", "internal", "bundlemirror", "mirror.go")
+	_, err := os.Stat(marker)
+	return err == nil
+}

--- a/docs/spec/atomic-doctor.md
+++ b/docs/spec/atomic-doctor.md
@@ -29,7 +29,7 @@ Design source: `docs/design/atomic-doctor.md`.
 - [ ] `--fix` prompts per item (axiom 3); no batched silent mutations.
 - [ ] `--only <cat>` / `--skip <cat>` accept category indices or canonical short names.
 - [ ] Missing `~/.claude/` short-circuits to exit 0 with one informational line; no FAIL cascade.
-- [ ] Repo-dev-only checks (manifest parity) skip silently when not in the atomic-claude repo.
+- [ ] Repo-dev-only checks (manifest parity) are omitted entirely (no result row, no `SKIP`) when not in the atomic-claude repo, unless explicitly requested via `--only`.
 - [ ] All checks deterministic — no LLM judgment, pure Go.
 - [ ] `go test ./atomic/internal/doctor/...` covers each check + each repair with table-driven cases.
 
@@ -67,7 +67,7 @@ Indexed. Numbers are stable; **never renumber**. New checks append.
 | 2 | `hooks`          | `~/.claude/settings.json` contains the session-start hook payload that `atomic hooks session-start` would emit. | WARN |
 | 3 | `signals`        | `.claude/project/deterministic-signals.md` exists; `atomic signals stale --threshold <days>` exits 0. Threshold defaults to 7; overridable via `--stale-days`. | WARN |
 | 4 | `refs`           | `@.claude/project/signals.md` ref present in one of `claude.local.md` / `CLAUDE.local.md` / `CLAUDE.md` / `claude.md` (skill search order). Only `signals.md` is @-ref'd; `deterministic-signals.md` is read on demand by the inferrer. | FAIL |
-| 5 | `manifest`       | Repo-dev only (heuristic: `atomic/internal/bundlemirror/` exists). Committed `manifest.go` SHA matches what `go generate ./...` would produce — without writing. | FAIL |
+| 5 | `manifest`       | Repo-dev only (heuristic: `atomic/internal/bundlemirror/` exists). Committed `manifest.go` SHA matches what `go generate ./...` would produce — without writing. Omitted entirely outside the repo (no row, no `SKIP`) unless explicitly requested via `--only 5`. | FAIL |
 | 6 | `followups`      | If `.claude/project/followups.md` exists, every `### F-<id>` entry has an `Origin:` line and a severity bucket. | WARN |
 | 7 | `memory`         | `~/.claude/projects/<project>/memory/MEMORY.md` link targets all resolve (file exists in same dir). | WARN |
 | 8 | `binary`         | `atomic update --check` succeeds without performing update. | WARN |
@@ -87,7 +87,7 @@ Default: 7 days. Overridable per-invocation via `--stale-days N`. No persistent 
 ## Repo-dev detection
 
 
-A run counts as "in the atomic-claude repo" iff `atomic/internal/bundlemirror/mirror.go` exists relative to the git toplevel of the cwd. When false, category 5 is skipped (status `SKIP`, no PASS/WARN/FAIL counted).
+A run counts as "in the atomic-claude repo" iff `atomic/internal/bundlemirror/mirror.go` exists relative to the git toplevel of the cwd. When false, category 5 (`manifest`, flagged `RepoDevOnly` in the registry) is **omitted entirely** — no result row, not counted in the summary, no `SKIP` line — so end users never see repo-development noise. An explicit `--only 5` overrides the auto-omit and runs the check, which then self-reports `SKIP — not in atomic-claude repo`.
 
 
 ## Output format (human)
@@ -100,12 +100,11 @@ atomic doctor — integrity check  (project: <name>)
 [2] WARN  hooks                    session-start hook missing
 [3] PASS  signals                  last scan 3d ago (threshold 7d)
 [4] FAIL  refs                     @-refs not present in CLAUDE.md, claude.local.md, CLAUDE.local.md, or claude.md
-[5] SKIP  manifest                 not in atomic-claude repo
 [6] PASS  followups                no .claude/project/followups.md
 [7] PASS  memory                   8/8 refs resolve
 [8] PASS  binary                   v0.4.2 (latest)
 
-5 PASS, 1 WARN, 1 FAIL, 1 SKIP. exit 1.
+5 PASS, 1 WARN, 1 FAIL, 0 SKIP. exit 1.
 
 To repair: atomic doctor --fix
 ```
@@ -355,3 +354,11 @@ Built across 11 iterations of `/subagent-implementation` (8 checkpoints + 1 spec
 **Correction:** The spec's Surface table (line 52) has always promised `--verbose` "Print per-file detail for install integrity and manifest parity" — but no implementation ever rendered it. This amendment makes the body match the long-standing contract rather than introducing new behavior. How we know it was wrong: the flag's effect was untestable because no code read `opts.Verbose`.
 
 **Known gaps (filed as followups):** `manifest` `missing:`/`extra:` Finding prefixes are implemented but only the `drifted:` path is test-covered (`doctor-verbose-f-1`). `FixApplied`/`FixSummary` render correctly but no `--fix` repair path populates them yet (`doctor-verbose-f-2`).
+
+### 2026-06-06 — repo-dev-only checks omitted outside the atomic-claude repo
+
+**What changed:** Category 5 (`manifest`) is now flagged `RepoDevOnly` in the category registry. When `atomic doctor` runs outside the atomic-claude repo (detected from cwd via `IsRepoDev`), the manifest check is omitted from results entirely — no `SKIP` line, not counted in the summary. An explicit `--only 5` overrides the auto-omit and runs the check (which then self-reports its existing `SKIP — not in atomic-claude repo`). `Run` now delegates to an exported `RunWith(opts, repoDev bool)` seam so the repo-dev verdict is injectable for tests; `isRepoDevCwd()` resolves it from cwd best-effort (getwd/detection error → false).
+
+**Why:** Issue #35 follow-on. Manifest parity is a contributor/CI concern; end users running `atomic doctor` in their own projects previously saw a `[5] SKIP manifest  not in atomic-claude repo` line that only made sense to repo developers. Omitting the check entirely removes the repo-development noise while keeping it fully functional in-repo and on explicit request.
+
+**Superseded:** Prior contract always registered and ran category 5, emitting a `SKIP` result line outside the atomic-claude repo.

--- a/docs/spec/atomic-validate.md
+++ b/docs/spec/atomic-validate.md
@@ -74,6 +74,14 @@ v1.1 adds: `atomic validate design`, `atomic validate followups`.
 Path-aware dispatch: `atomic validate docs/spec/foo.md other/path.md` routes the first to `spec`, ignores (with WARN) the second.
 
 
+**Bundle is repo-dev-only.** Bundle parity compares the working tree against the embedded source snapshot, which only exists in the atomic-claude repo (detected by the presence of `atomic/internal/bundlemirror/mirror.go` at the git toplevel — the same heuristic as `atomic doctor`'s manifest check). Outside that repo:
+
+- Bare `atomic validate` runs spec + config only; the bundle section is omitted silently (no header, no findings).
+- Explicit `atomic validate bundle` (and `--json`) prints a one-line `SKIP — not in atomic-claude repo` and exits 0.
+
+It never errors out. spec and config validators run in any repo.
+
+
 ## v1 rules
 
 
@@ -288,3 +296,11 @@ Closed during the build (dropped from ledger; commits cover them): F-1 (flag-aft
 
 
 **Squashed onto `main` as `82cd9cc` — 2026-05-18.** Per-iteration SHAs above are historical (unreachable post-squash).
+
+### 2026-06-06 — bundle check skips outside the atomic-claude repo
+
+**What changed:** The bundle-parity validator is now repo-dev-gated. Bare `atomic validate` run outside the atomic-claude repo runs only the spec + config validators; the bundle section is omitted silently (no header, no findings). Explicit `atomic validate bundle` (and `--json`) outside the repo prints a one-line `SKIP — not in atomic-claude repo` and exits 0 instead of crashing. Repo-dev detection mirrors `doctor.IsRepoDev` (presence of `atomic/internal/bundlemirror/mirror.go`) via a local `repoDev(root)` helper in `internal/validate/repo.go` — no doctor import. The no-`.git` hard error was removed from the explicit bundle path (it now skips cleanly); whole-repo dispatch still requires a repo root for spec/config.
+
+**Why:** Issue #35 — `atomic validate` crashed with `bundle check failed: internal error (exit 2)` in any project that is not the atomic-claude repo itself, because bundle parity compares the working tree against the embedded source snapshot, which only exists in-repo. `manifestcheck.Compare` returned an error on the absent source and the dispatcher mapped it to exit 2. Bundle parity is a contributor/CI concern; end users running `atomic validate` in their own projects should get the spec + config checks that actually apply, not a crash.
+
+**Superseded:** Prior contract ran the bundle validator unconditionally in all three entry points (bare `validate`, `validate bundle`, `--json`), erroring out (exit 2) outside the atomic-claude repo.


### PR DESCRIPTION
## Summary

`atomic validate` crashed with `bundle check failed: internal error (exit 2)` in any project that is not the atomic-claude repo itself (issue #35). Bundle parity compares the working tree against the embedded source snapshot, which only exists in-repo.

Bundle parity is a contributor/CI concern. This gates it behind a repo-dev heuristic (presence of `atomic/internal/bundlemirror/mirror.go`, mirroring `doctor.IsRepoDev`):

- bare `atomic validate` outside the repo runs spec + config only; bundle omitted silently
- explicit `atomic validate bundle` (and `--json`) prints a one-line `SKIP` and exits 0
- doctor category 5 (`manifest`) is flagged `RepoDevOnly` and omitted entirely outside the repo (no row, no `SKIP`), unless `--only 5`

In-repo behavior unchanged: manifest + bundle parity still run.

## Test plan

- New tests: 4 in `internal/validate` (whole-repo skip, repo-dev include, bundle SKIP human + JSON), 3 in `internal/doctor` (omit / include / explicit-only). All green.
- Full `go test ./...` passes; `go vet` + `gofmt` clean.
- Verified live against a fresh external git repo: `validate`, `validate --json`, `validate bundle` all exit 0; `doctor` omits the manifest row. In-repo: `[5] PASS manifest`, bundle runs.

Specs updated to current truth + change-log entries: `docs/spec/atomic-validate.md`, `docs/spec/atomic-doctor.md`.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)