### PR TITLE
feat(codeintel): wire Phoenix route resolver to Elixir

### DIFF
--- a/atomic/internal/codeintel/extraction/binding.go
+++ b/atomic/internal/codeintel/extraction/binding.go
@@ -52,6 +52,7 @@ const (
 	LangLuau            // Luau
 	LangObjC            // Objective-C
 	LangPascal          // Pascal
+	LangElixir          // Elixir
 )
 
 // ---------------------------------------------------------------------------

--- a/atomic/internal/codeintel/extraction/extractor.go
+++ b/atomic/internal/codeintel/extraction/extractor.go
@@ -132,6 +132,14 @@ type LanguageExtractor struct {
 	// called; for NodeKindStruct (or any other value), extractStruct is called.
 	ResolveKind func(ctx context.Context, node sitter.Node, source string) types.NodeKind
 
+	// GetName returns the name string for a node, overriding the normal NameField
+	// fallback path in nameFromNode. It is called with the original (pre-ResolveBody)
+	// grammar node. Returns "" to fall through to the normal name extraction.
+	// Use this when the grammar requires looking at sibling children to determine
+	// the symbol name (e.g. Elixir, where def/defmodule macros encode the name
+	// in a different child than what ResolveBody navigates to for body traversal).
+	GetName func(ctx context.Context, node sitter.Node, source string) string
+
 	// GetSignature returns the human-readable signature string for a node.
 	// Returns "" when not applicable.
 	GetSignature func(ctx context.Context, node sitter.Node, source string) string
@@ -455,6 +463,22 @@ func (v *visitor) visitNode(ctx context.Context, node sitter.Node, kind string) 
 					return true, v.extractTypeAlias(ctx, node)
 				case types.NodeKindEnum:
 					return true, v.extractEnum(ctx, node)
+				// Extended dispatch paths for grammars (e.g. Elixir) where definitions
+				// and regular calls share a single node kind and are differentiated by
+				// child-node text inside ResolveKind.
+				case types.NodeKindFunction:
+					return true, v.extractFunction(ctx, node)
+				case types.NodeKindModule:
+					return true, v.extractClass(ctx, node, types.NodeKindModule)
+				case types.NodeKindImport:
+					return true, v.extractImport(ctx, node)
+				case types.NodeKind(""):
+					// Empty sentinel: ResolveKind signals "emit as call reference,
+					// not a declaration". Used by Elixir to handle regular call nodes
+					// (e.g. User.new(params)) that happen to share the "call" node kind
+					// with definition macros (defmodule, def, …).
+					v.extractCall(ctx, node, false)
+					return true, nil
 				default:
 					// NodeKindStruct or any unrecognised value → struct path.
 				}
@@ -664,9 +688,18 @@ func (v *visitor) extractFunction(ctx context.Context, node sitter.Node) error {
 		}
 	}
 
-	name, err := v.nameFromNode(ctx, resolved)
-	if err != nil || name == "" {
-		name, _ = v.nameFromNode(ctx, node)
+	// GetName hook overrides nameFromNode when set. Called with the original
+	// unresolved node so the hook can navigate to the right child (e.g. Elixir
+	// def macros encode the function name in a different child than the body).
+	var name string
+	if v.cfg.GetName != nil {
+		name = v.cfg.GetName(ctx, node, v.src)
+	}
+	if name == "" {
+		name, err = v.nameFromNode(ctx, resolved)
+		if err != nil || name == "" {
+			name, _ = v.nameFromNode(ctx, node)
+		}
 	}
 
 	n, err := v.createNode(ctx, node, nodeKind, name)
@@ -701,9 +734,15 @@ func (v *visitor) extractClass(ctx context.Context, node sitter.Node, kind types
 		resolved = node
 	}
 
-	name, err := v.nameFromNode(ctx, resolved)
-	if err != nil || name == "" {
-		name, _ = v.nameFromNode(ctx, node)
+	var name string
+	if v.cfg.GetName != nil {
+		name = v.cfg.GetName(ctx, node, v.src)
+	}
+	if name == "" {
+		name, err = v.nameFromNode(ctx, resolved)
+		if err != nil || name == "" {
+			name, _ = v.nameFromNode(ctx, node)
+		}
 	}
 
 	n, err := v.createNode(ctx, node, kind, name)
@@ -748,9 +787,15 @@ func (v *visitor) extractStruct(ctx context.Context, node sitter.Node) error {
 		resolved = node
 	}
 
-	name, err := v.nameFromNode(ctx, resolved)
-	if err != nil || name == "" {
-		name, _ = v.nameFromNode(ctx, node)
+	var name string
+	if v.cfg.GetName != nil {
+		name = v.cfg.GetName(ctx, node, v.src)
+	}
+	if name == "" {
+		name, err = v.nameFromNode(ctx, resolved)
+		if err != nil || name == "" {
+			name, _ = v.nameFromNode(ctx, node)
+		}
 	}
 
 	n, err := v.createNode(ctx, node, types.NodeKindStruct, name)
@@ -1321,6 +1366,26 @@ func (v *visitor) visitFunctionBody(ctx context.Context, body sitter.Node) {
 		// Check for calls.
 		if v.cfg.CallTypes != nil {
 			if _, ok := v.cfg.CallTypes[kind]; ok {
+				// When this node kind is ALSO in StructTypes and ResolveKind is set,
+				// check whether ResolveKind classifies it as a definition (non-empty
+				// non-"" kind) or as a call reference (empty ""). This is required for
+				// grammars like Elixir where definition macros and regular function calls
+				// share the same "call" node kind: defmodule/def/defp are definitions
+				// (ResolveKind returns a real NodeKind), while User.new() is a call
+				// (ResolveKind returns ""). Without this check, all "call" nodes in a
+				// function body would be treated as call references, incorrectly emitting
+				// def/defmodule nodes as EdgeKindCalls entries.
+				if v.cfg.StructTypes != nil && v.cfg.ResolveKind != nil {
+					if _, inStruct := v.cfg.StructTypes[kind]; inStruct {
+						resolved := v.cfg.ResolveKind(ctx, child, v.src)
+						if resolved != types.NodeKind("") {
+							// It's a definition node — skip the extractCall path.
+							// visitChildren (called by the parent extractClass) handles
+							// it via the StructTypes/ResolveKind dispatch in visitNode.
+							continue
+						}
+					}
+				}
 				v.extractCall(ctx, child, false)
 				continue
 			}

--- a/atomic/internal/codeintel/extraction/languages/elixir.go
+++ b/atomic/internal/codeintel/extraction/languages/elixir.go
@@ -1,0 +1,288 @@
+package languages
+
+// Elixir language extractor configuration.
+//
+// Verified node-type strings (probed via tmp/probe-elixir/ — Elixir grammar
+// tree-sitter-elixir v0.3.5, ABI 14):
+//
+// All Elixir constructs parse as "call" nodes. The macro name lives in the
+// node's "target" field (an identifier child). The second named child
+// (index 1) is an "arguments" node. Definitions are macros — structurally
+// identical to regular function calls; only the target identifier text
+// distinguishes them.
+//
+//	call.target → identifier text:
+//	  "defmodule" — module definition; module name in arguments[0] (alias node)
+//	  "def"       — public function; function spec in arguments[0] (inner call node)
+//	  "defp"      — private function; same structure as "def"
+//	  "defstruct" — struct definition; fields in arguments[0] (list node)
+//	  "defmacro"  — macro definition; treated as public function for graph purposes
+//	  "alias"     — module alias directive; module in arguments[0] (alias node)
+//	  "import"    — import directive; module in arguments[0] (alias node)
+//	  "use"       — use directive; module in arguments[0] (alias node)
+//	  anything else (dot target or unknown identifier) → regular call reference
+//
+// Name extraction:
+//   - defmodule/alias/import/use: ResolveBody returns arguments[0] (alias leaf),
+//     nameFromNode fallback returns full alias text (e.g. "MyApp.UserController").
+//   - def/defp/defmacro: ResolveBody returns arguments[0] (inner call node),
+//     nameFromNode fallback returns its first identifier child (the function name).
+//   - defstruct: ResolveBody returns the outer call node; nameFromNode finds the
+//     "defstruct" identifier as first named child → name = "defstruct". The
+//     qualified name (e.g. "MyApp.Foo::defstruct") is unique within the module.
+//
+// IsExported rule:
+//   - defmodule, defstruct, alias, import, use → true (public by nature)
+//   - def, defmacro → true
+//   - defp → false (private function)
+//
+// Edges:
+//   - alias/import/use macro calls → emitted as NodeKindImport (via ResolveKind).
+//   - Regular function calls (non-macro) → emitted as call UnresolvedReferences
+//     (via the "" sentinel from ResolveKind).
+//   - Nested calls inside def/defp bodies are captured by visitFunctionBody
+//     because "call" is also in CallTypes. CallTypes IS set (to "call"); body-level
+//     call extraction is active. Definition macros are filtered OUT inside
+//     visitFunctionBody via the StructTypes+ResolveKind guard: when ResolveKind
+//     returns a non-"" kind (e.g. NodeKindFunction for "def"), the node is a
+//     definition already extracted by the visitChildren path and is skipped.
+//     Only nodes where ResolveKind returns "" (regular function calls like
+//     User.new/json/etc.) reach extractCall and emit an UnresolvedReference.
+//
+// NOTE: Because ALL "call" nodes go through StructTypes → ResolveKind, and
+// ResolveKind returns "" (the call-ref sentinel) for non-definition calls,
+// every non-macro call encountered at the file/module/function scope level emits
+// an UnresolvedReference via extractCall. This covers alias/import/use as import
+// nodes AND local/remote function calls at the top level of bodies. Body-level
+// calls are also captured: visitFunctionBody checks CallTypes (set to "call"),
+// and the StructTypes+ResolveKind guard filters definition macros so only genuine
+// call references are emitted from body scanning.
+//
+// Probe files: tmp/probe-elixir/main.go, probe2.go, probe3.go, probe4.go
+
+import (
+	"context"
+	"strings"
+
+	sitter "github.com/malivvan/tree-sitter"
+
+	"github.com/damusix/atomic-claude/atomic/internal/codeintel/extraction"
+	"github.com/damusix/atomic-claude/atomic/internal/codeintel/types"
+)
+
+// elixirTargetText returns the text of the "target" field of an Elixir call node.
+// Returns "" if the target field is absent or is not an identifier (e.g. a dot
+// call like User.new(…) has a "dot" target, not an identifier).
+func elixirTargetText(ctx context.Context, node sitter.Node, src string) string {
+	target, err := node.ChildByFieldName(ctx, "target")
+	if err != nil {
+		return ""
+	}
+	isNull, _ := target.IsNull(ctx)
+	if isNull {
+		return ""
+	}
+	kind, _ := target.Kind(ctx)
+	if kind != "identifier" {
+		return "" // dot call (Mod.fun) — not a definition macro
+	}
+	ts, _ := target.StartByte(ctx)
+	te, _ := target.EndByte(ctx)
+	if int(te) > len(src) {
+		return ""
+	}
+	return src[ts:te]
+}
+
+// elixirArgsFirstChild returns the first named child of the arguments node
+// (named child index 1 of the call node). Returns (zero, false) when absent.
+func elixirArgsFirstChild(ctx context.Context, node sitter.Node) (sitter.Node, bool) {
+	cnt, err := node.NamedChildCount(ctx)
+	if err != nil || cnt < 2 {
+		return sitter.Node{}, false
+	}
+	argsNode, err := node.NamedChild(ctx, 1) // named child [1] = arguments wrapper
+	if err != nil {
+		return sitter.Node{}, false
+	}
+	isNull, _ := argsNode.IsNull(ctx)
+	if isNull {
+		return sitter.Node{}, false
+	}
+	argCnt, err := argsNode.NamedChildCount(ctx)
+	if err != nil || argCnt == 0 {
+		return sitter.Node{}, false
+	}
+	first, err := argsNode.NamedChild(ctx, 0)
+	if err != nil {
+		return sitter.Node{}, false
+	}
+	isNull, _ = first.IsNull(ctx)
+	if isNull {
+		return sitter.Node{}, false
+	}
+	return first, true
+}
+
+// elixirGetName extracts the symbol name from an Elixir call node without
+// affecting body traversal. Used as the GetName hook so that ResolveBody can
+// safely return the original call node (enabling visitChildren to descend into
+// the do_block) while GetName independently extracts the correct name.
+//
+// Name strategy per macro:
+//   - defmodule: args[0] is alias("MyApp.Foo") → full text = "MyApp.Foo"
+//   - def/defp/defmacro: args[0] is inner call("bar(x)") → target text = "bar"
+//   - defstruct: args[0] is list → name = "defstruct" (unique within module)
+//   - alias/import/use: args[0] is alias("MyApp.User") → full text = "MyApp.User"
+//   - anything else: returns "" (fall through to nameFromNode)
+func elixirGetName(ctx context.Context, node sitter.Node, src string) string {
+	macro := elixirTargetText(ctx, node, src)
+	switch macro {
+	case "defmodule", "alias", "import", "use":
+		// Name = text of arguments[0] (alias/module-path node).
+		if first, ok := elixirArgsFirstChild(ctx, node); ok {
+			ts, _ := first.StartByte(ctx)
+			te, _ := first.EndByte(ctx)
+			if int(te) <= len(src) {
+				return strings.TrimSpace(src[ts:te])
+			}
+		}
+		return macro
+	case "def", "defp", "defmacro":
+		// Name = "target" text of the inner call node (arguments[0]).
+		// The inner call is bar(x); its target field is identifier("bar").
+		if first, ok := elixirArgsFirstChild(ctx, node); ok {
+			kind, _ := first.Kind(ctx)
+			if kind == "call" {
+				return elixirTargetText(ctx, first, src)
+			}
+			// Guard: if the args structure is flat (no-arg function like `def foo`),
+			// first child may itself be an identifier.
+			if kind == "identifier" {
+				ts, _ := first.StartByte(ctx)
+				te, _ := first.EndByte(ctx)
+				if int(te) <= len(src) {
+					return strings.TrimSpace(src[ts:te])
+				}
+			}
+		}
+		return macro
+	case "defstruct":
+		// Elixir convention: there is exactly one defstruct per module. Use the
+		// fixed name "defstruct" so the qualified name is "MyApp.Foo::defstruct".
+		return "defstruct"
+	}
+	return "" // fall through to nameFromNode for unrecognised macros / regular calls
+}
+
+// ElixirExtractor returns the LanguageExtractor config for Elixir source files (.ex, .exs).
+//
+// Node-type strings are verified by parsing real Elixir via the wazero binding
+// (see tmp/probe-elixir/ for exact output).
+func ElixirExtractor() extraction.LanguageExtractor {
+	return extraction.LanguageExtractor{
+		// All Elixir constructs are "call" nodes. StructTypes is used because it
+		// is the only dispatch path that supports ResolveKind to fan out a single
+		// node kind to multiple semantic roles (module, function, struct, import,
+		// or call reference). The ResolveKind hook reads the "target" identifier
+		// text to decide which semantic role applies.
+		StructTypes: extraction.TypeSet("call"),
+
+		// NameField is intentionally empty. Name extraction is handled entirely
+		// by the GetName hook — which reads the correct inner child per macro —
+		// and by nameFromNode fallback when GetName returns "".
+		NameField: "",
+
+		// GetName extracts the symbol name from the original call node, independent
+		// of which node ResolveBody returns. This separation is required because:
+		//   - ResolveBody must return the original call node (so visitChildren
+		//     descends into the do_block and finds nested def/defp/defstruct).
+		//   - The name lives in a different child (arguments[0] or its sub-tree),
+		//     not in the call node directly.
+		// See elixirGetName for the per-macro strategy.
+		GetName: elixirGetName,
+
+		// CallTypes enables body-level call extraction in visitFunctionBody.
+		// "call" is used here because ALL Elixir calls (regular and macro) share
+		// this node kind. The definition macros (def, defmodule, etc.) are
+		// filtered OUT in visitFunctionBody via the StructTypes+ResolveKind guard:
+		// when a "call" node's ResolveKind returns a non-"" kind, it is a
+		// definition — visitFunctionBody skips it (it was already extracted by
+		// the visitChildren path). Only nodes where ResolveKind returns "" (i.e.
+		// regular function calls like User.new/json/etc.) reach extractCall.
+		CallTypes: extraction.TypeSet("call"),
+
+		// ResolveKind inspects the "target" identifier text of a call node and
+		// returns the appropriate NodeKind:
+		//   defmodule → NodeKindModule
+		//   def / defmacro → NodeKindFunction (IsExported=true)
+		//   defp → NodeKindFunction (IsExported=false, via IsExported hook)
+		//   defstruct → NodeKindStruct
+		//   alias / import / use → NodeKindImport
+		//   anything else → "" (empty sentinel = emit as call reference)
+		ResolveKind: func(ctx context.Context, node sitter.Node, src string) types.NodeKind {
+			switch elixirTargetText(ctx, node, src) {
+			case "defmodule":
+				return types.NodeKindModule
+			case "def", "defmacro":
+				return types.NodeKindFunction
+			case "defp":
+				return types.NodeKindFunction
+			case "defstruct":
+				return types.NodeKindStruct
+			case "alias", "import", "use":
+				return types.NodeKindImport
+			default:
+				return types.NodeKind("") // call reference sentinel
+			}
+		},
+
+		// ResolveBody returns the ORIGINAL call node for all macros.
+		//
+		// Rationale: extractClass/extractFunction call BOTH GetName (for name) AND
+		// visitChildren (for body traversal) on the resolved node. Returning the
+		// original call node means visitChildren descends into all named children —
+		// including the do_block — and finds nested def/defp/defstruct nodes.
+		//
+		// If we returned arguments[0] (the alias or inner call), visitChildren
+		// would walk the alias node (no children) or inner call (its arguments),
+		// missing the do_block entirely. GetName provides the correct name
+		// independent of this decision.
+		//
+		// For the "" sentinel (regular calls), ResolveBody is never called because
+		// the ResolveKind "" case dispatches directly to extractCall.
+		ResolveBody: func(ctx context.Context, node sitter.Node, src string) (sitter.Node, error) {
+			// Return original node unchanged. GetName handles name extraction;
+			// visitChildren handles body traversal via do_block.
+			return node, nil
+		},
+
+		// IsExported: defp functions are private (IsExported=false); everything
+		// else is public. The hook receives the original call node (before
+		// ResolveBody), so we read the target text here.
+		//
+		// IsExportedByName is not used because export status depends on the macro
+		// keyword, not the symbol name.
+		IsExported: func(ctx context.Context, node sitter.Node, src string) bool {
+			return elixirTargetText(ctx, node, src) != "defp"
+		},
+
+		// ExtractImport extracts the module path from alias/import/use nodes.
+		// The path is the text of arguments[0] (the alias node).
+		ExtractImport: func(ctx context.Context, node sitter.Node, src string) (name string, path string) {
+			if first, ok := elixirArgsFirstChild(ctx, node); ok {
+				ts, _ := first.StartByte(ctx)
+				te, _ := first.EndByte(ctx)
+				if int(te) <= len(src) {
+					path = strings.TrimSpace(src[ts:te])
+					name = path
+				}
+			}
+			if name == "" {
+				macro := elixirTargetText(ctx, node, src)
+				name = macro
+			}
+			return name, path
+		},
+	}
+}

--- a/atomic/internal/codeintel/extraction/languages/elixir_test.go
+++ b/atomic/internal/codeintel/extraction/languages/elixir_test.go
@@ -1,0 +1,246 @@
+package languages_test
+
+// Tests for the Elixir language extractor config (CP2: engine wiring + extractor).
+//
+// Each test:
+//  1. Extracts a real fixture through the pool (proves grammar ABI + wiring ok).
+//  2. Asserts per success criteria:
+//     - defmodule → NodeKindModule (module name extracted from alias)
+//     - def       → NodeKindFunction, IsExported=true
+//     - defp      → NodeKindFunction, IsExported=false
+//     - defstruct → NodeKindStruct
+//     - alias/import/use → NodeKindImport (UnresolvedReference with EdgeKindImports)
+//     - regular calls → UnresolvedReference with EdgeKindCalls
+//     - Node count stable across two extractions.
+//
+// Node-type strings are VERIFIED by real Elixir grammar parse (see
+// tmp/probe-elixir/ for probe output). Do NOT change them without re-running
+// the probe — all Elixir constructs parse as "call" nodes.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/damusix/atomic-claude/atomic/internal/codeintel/types"
+	"github.com/damusix/atomic-claude/atomic/internal/codeintel/extraction/languages"
+)
+
+// elixirFixture exercises:
+//   - defmodule (MyApp.UserController)  → NodeKindModule
+//   - alias (MyApp.User)                → NodeKindImport
+//   - import (Plug.Conn)                → NodeKindImport
+//   - use (Phoenix.Controller)          → NodeKindImport
+//   - defstruct ([:id, :name, :email])  → NodeKindStruct
+//   - def create(conn, params)          → NodeKindFunction, IsExported=true
+//   - def index(conn, _params)          → NodeKindFunction, IsExported=true
+//   - defp validate(params)             → NodeKindFunction, IsExported=false
+//   - regular call User.new(params)     → UnresolvedReference EdgeKindCalls
+//   - regular call json(conn, user)     → UnresolvedReference EdgeKindCalls
+//
+// Verified by tmp/probe-elixir/: all Elixir definitions parse as "call" nodes
+// with a "target" identifier child whose text is the macro name.
+const elixirFixture = `defmodule MyApp.UserController do
+  alias MyApp.User
+  import Plug.Conn
+  use Phoenix.Controller
+
+  defstruct [:id, :name, :email]
+
+  def create(conn, params) do
+    user = User.new(params)
+    json(conn, user)
+  end
+
+  def index(conn, _params) do
+    users = User.all()
+    json(conn, users)
+  end
+
+  defp validate(params) do
+    params
+  end
+end
+`
+
+const elixirFixturePath = "lib/my_app/user_controller.ex"
+
+// TestElixir_ModuleExtracted verifies defmodule → NodeKindModule with the
+// correct module name extracted from the alias node.
+// WHY: Module nodes are the structural containers for Elixir code; missing
+// them breaks the entire module-level graph.
+func TestElixir_ModuleExtracted(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	mod := findNode(result.Nodes, types.NodeKindModule, "MyApp.UserController")
+	if mod == nil {
+		t.Fatalf("MyApp.UserController module not found as NodeKindModule; nodes: %s", nodeKindList(result.Nodes))
+	}
+}
+
+// TestElixir_PublicFunctionExtracted verifies def → NodeKindFunction with IsExported=true.
+// WHY: Public functions are the primary call targets in Elixir; wrong kind or
+// wrong export flag breaks call-graph resolution and Phoenix route wiring.
+func TestElixir_PublicFunctionExtracted(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	fn := findNode(result.Nodes, types.NodeKindFunction, "create")
+	if fn == nil {
+		t.Fatalf("create function not found; nodes: %s", nodeKindList(result.Nodes))
+	}
+	if !fn.IsExported {
+		t.Errorf("create should be exported (def); got IsExported=false")
+	}
+}
+
+// TestElixir_PrivateFunctionExtracted verifies defp → NodeKindFunction with IsExported=false.
+// WHY: Private functions must be distinguished from public ones; a Phoenix route
+// resolver must not expose defp functions as routable actions.
+func TestElixir_PrivateFunctionExtracted(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	fn := findNode(result.Nodes, types.NodeKindFunction, "validate")
+	if fn == nil {
+		t.Fatalf("validate function not found; nodes: %s", nodeKindList(result.Nodes))
+	}
+	if fn.IsExported {
+		t.Errorf("validate should not be exported (defp); got IsExported=true")
+	}
+}
+
+// TestElixir_StructExtracted verifies defstruct → NodeKindStruct.
+// WHY: Elixir structs are the primary data types; their extraction enables
+// type-reference resolution and data-flow analysis.
+func TestElixir_StructExtracted(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	var structNode *types.Node
+	for i := range result.Nodes {
+		if result.Nodes[i].Kind == types.NodeKindStruct {
+			structNode = &result.Nodes[i]
+			break
+		}
+	}
+	if structNode == nil {
+		t.Fatalf("defstruct node not found as NodeKindStruct; nodes: %s", nodeKindList(result.Nodes))
+	}
+}
+
+// TestElixir_ImportsExtracted verifies alias/import/use → NodeKindImport.
+// WHY: Import nodes enable dependency tracking between Elixir modules; without
+// them the graph has no edges between the user controller and MyApp.User.
+func TestElixir_ImportsExtracted(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	importNode := findNode(result.Nodes, types.NodeKindImport, "MyApp.User")
+	if importNode == nil {
+		t.Fatalf("MyApp.User import not found; nodes: %s", nodeKindList(result.Nodes))
+	}
+}
+
+// TestElixir_CallEmitsUnresolvedReference verifies regular call nodes emit
+// EdgeKindCalls UnresolvedReferences (not edges directly).
+// WHY: Calls must never emit edges directly — the resolution layer owns that
+// step. A direct edge at extraction time bypasses resolution and produces an
+// incorrect, unresolvable graph entry.
+func TestElixir_CallEmitsUnresolvedReference(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	// Fixture has regular calls: User.new(params), json(conn, user), User.all().
+	// These should emit EdgeKindCalls UnresolvedReferences, NOT NodeKindFunction nodes.
+	callRefs := countUnresolved(result.UnresolvedReferences, types.EdgeKindCalls)
+	if callRefs == 0 {
+		t.Fatalf("no EdgeKindCalls UnresolvedReferences; fixture has User.new(params), json(conn, user), User.all(); refs: %v", result.UnresolvedReferences)
+	}
+}
+
+// TestElixir_NodeCountStable verifies extraction is deterministic (idempotent).
+// WHY: Non-deterministic extraction (e.g. from pointer aliasing or global state)
+// causes flaky test failures and unreliable incremental indexing.
+func TestElixir_NodeCountStable(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+
+	r1 := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	r2 := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+
+	if len(r1.Nodes) != len(r2.Nodes) {
+		t.Errorf("node count not stable: %d vs %d", len(r1.Nodes), len(r2.Nodes))
+	}
+	if len(r1.UnresolvedReferences) != len(r2.UnresolvedReferences) {
+		t.Errorf("unresolved ref count not stable: %d vs %d", len(r1.UnresolvedReferences), len(r2.UnresolvedReferences))
+	}
+}
+
+// TestElixir_NonZeroExtraction verifies that a real .ex file produces > 0 nodes.
+// WHY: This is the primary regression gate — if Elixir extraction silently
+// regresses to 0 nodes (e.g. grammar not loaded, wiring broken), this test
+// fails immediately.
+func TestElixir_NonZeroExtraction(t *testing.T) {
+	cfg, extLang, ok := languages.NewRegistry().For(types.LanguageElixir)
+	if !ok {
+		t.Fatal("Elixir not registered")
+	}
+	e := newExtractor(t, extLang, cfg)
+	result := e.Extract(context.Background(), elixirFixturePath, elixirFixture, types.LanguageElixir)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+
+	// Must extract: 1 file node + 1 module + 2 public functions + 1 private function
+	// + 1 struct + at least 3 import nodes = minimum 9 nodes.
+	if len(result.Nodes) < 9 {
+		t.Errorf("expected >= 9 nodes (file+module+functions+struct+imports), got %d; nodes: %s",
+			len(result.Nodes), nodeKindList(result.Nodes))
+	}
+}

--- a/atomic/internal/codeintel/extraction/languages/registry.go
+++ b/atomic/internal/codeintel/extraction/languages/registry.go
@@ -18,11 +18,11 @@ type registryEntry struct {
 }
 
 // NewRegistry builds and returns a fully-initialised Registry containing the
-// twenty-one language configs: Go, TypeScript, JavaScript, TSX, JSX, Python, Rust,
-// Java, C, C++, C#, Swift, Kotlin, Scala, Ruby, PHP, Lua, Luau, Dart, ObjC, Pascal.
+// twenty-two language configs: Go, TypeScript, JavaScript, TSX, JSX, Python, Rust,
+// Java, C, C++, C#, Swift, Kotlin, Scala, Ruby, PHP, Lua, Luau, Dart, ObjC, Pascal, Elixir.
 func NewRegistry() *Registry {
 	r := &Registry{
-		entries: make(map[types.Language]registryEntry, 21),
+		entries: make(map[types.Language]registryEntry, 22),
 	}
 	r.entries[types.LanguageGo] = registryEntry{cfg: GoExtractor(), lang: extraction.LangGo}
 	r.entries[types.LanguageTypeScript] = registryEntry{cfg: TypeScriptExtractor(), lang: extraction.LangTypeScript}
@@ -45,6 +45,7 @@ func NewRegistry() *Registry {
 	r.entries[types.LanguageDart] = registryEntry{cfg: DartExtractor(), lang: extraction.LangDart}
 	r.entries[types.LanguageObjC] = registryEntry{cfg: ObjCExtractor(), lang: extraction.LangObjC}
 	r.entries[types.LanguagePascal] = registryEntry{cfg: PascalExtractor(), lang: extraction.LangPascal}
+	r.entries[types.LanguageElixir] = registryEntry{cfg: ElixirExtractor(), lang: extraction.LangElixir}
 	return r
 }
 

--- a/atomic/internal/codeintel/extraction/pool.go
+++ b/atomic/internal/codeintel/extraction/pool.go
@@ -254,6 +254,8 @@ func (ti *tsInstance) resolveLanguage(ctx context.Context, lang Lang) (sitter.La
 		return ts.LanguageObjC(ctx)
 	case LangPascal:
 		return ts.LanguagePascal(ctx)
+	case LangElixir:
+		return ts.LanguageElixir(ctx)
 	default:
 		return sitter.Language{}, fmt.Errorf("unknown language %d", lang)
 	}

--- a/atomic/internal/codeintel/indexer/orchestrator.go
+++ b/atomic/internal/codeintel/indexer/orchestrator.go
@@ -109,6 +109,9 @@ var extToLanguage = map[string]types.Language{
 	// Objective-C
 	".m":  types.LanguageObjC,
 	".mm": types.LanguageObjC,
+	// Elixir
+	".ex":  types.LanguageElixir,
+	".exs": types.LanguageElixir, // Elixir script (mix.exs, config.exs, test files)
 	// Pascal / Delphi
 	".pas": types.LanguagePascal,
 	".dpr": types.LanguagePascal, // Delphi project

--- a/atomic/internal/codeintel/resolution/frameworks/elixir.go
+++ b/atomic/internal/codeintel/resolution/frameworks/elixir.go
@@ -3,13 +3,11 @@
 // This file implements one FrameworkResolver + FrameworkExtractor pair for
 // the Phoenix web framework (Elixir).
 //
-// # Language — IMPORTANT
+// # Language
 //
-// Elixir is NOT in the 29-language set (appendix C of the code-intel-engine
-// spec). Route nodes and handler refs use types.LanguageUnknown. Languages()
-// returns [types.LanguageUnknown]. ClaimsReference and Resolve are implemented
-// for contract completeness even though no Elixir-language refs come from
-// extraction.
+// Elixir is a supported language (types.LanguageElixir). Route nodes and
+// handler refs carry LanguageElixir. Languages() returns [types.LanguageElixir]
+// so getApplicableResolvers includes this resolver when indexing .ex files.
 //
 // # Comment stripping
 //
@@ -89,9 +87,7 @@ var phoenixVerbRe = regexp.MustCompile(
 // ---------------------------------------------------------------------------
 
 // PhoenixResolver implements FrameworkResolver + FrameworkExtractor for Phoenix.
-//
-// NOTE: Elixir is absent from the 29-language set (appendix C). All route
-// nodes and refs use types.LanguageUnknown. See package doc.
+// Route nodes and refs carry LanguageElixir. See package doc.
 type PhoenixResolver struct {
 	projectRoot string
 	claimed     map[string]bool
@@ -105,10 +101,10 @@ func NewPhoenixResolver(projectRoot string) *PhoenixResolver {
 // Name returns "phoenix".
 func (r *PhoenixResolver) Name() string { return "phoenix" }
 
-// Languages returns [LanguageUnknown] because Elixir is not in the 29-language
-// set (appendix C). Route nodes and refs use LanguageUnknown for the same reason.
+// Languages returns [LanguageElixir]. The pipeline's getApplicableResolvers
+// matches this resolver to .ex files so Extract runs on Phoenix router files.
 func (r *PhoenixResolver) Languages() []types.Language {
-	return []types.Language{types.LanguageUnknown}
+	return []types.Language{types.LanguageElixir}
 }
 
 // Detect returns true when mix.exs in projectRoot contains `:phoenix` as a
@@ -124,7 +120,7 @@ func (r *PhoenixResolver) Detect(ctx context.Context) bool {
 // Extract scans filePath/content for Phoenix router verb lines and returns
 // route nodes + handler refs. # line comments are stripped first.
 //
-// Route nodes carry LanguageUnknown (Elixir absent from appendix C).
+// Route nodes and refs carry LanguageElixir.
 func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []types.UnresolvedReference) {
 	stripped := stripHashLineComments(content)
 	totalLines := strings.Count(content, "\n") + 1
@@ -145,8 +141,7 @@ func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []typ
 			line = totalLines
 		}
 
-		// LanguageUnknown: Elixir is not in the 29-language set (appendix C).
-		node := MakeRouteNode(filePath, line, verb, routePath, types.LanguageUnknown)
+		node := MakeRouteNode(filePath, line, verb, routePath, types.LanguageElixir)
 		nodes = append(nodes, node)
 
 		if action != "" {
@@ -158,7 +153,7 @@ func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []typ
 				ReferenceKind: types.EdgeKindReferences,
 				Line:          line,
 				FilePath:      filePath,
-				Language:      types.LanguageUnknown,
+				Language:      types.LanguageElixir,
 			})
 		}
 	}
@@ -170,8 +165,6 @@ func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []typ
 func (r *PhoenixResolver) ClaimsReference(name string) bool { return r.claimed[name] }
 
 // Resolve returns confidence 0.85 for claimed action names.
-// Implemented for contract completeness (no Elixir-language refs come from
-// extraction since Elixir is absent from appendix C).
 func (r *PhoenixResolver) Resolve(ctx context.Context, ref types.UnresolvedReference) (resolution.ResolvedRef, error) {
 	if !r.claimed[ref.ReferenceName] {
 		return resolution.ResolvedRef{}, nil

--- a/atomic/internal/codeintel/resolution/frameworks/elixir.go
+++ b/atomic/internal/codeintel/resolution/frameworks/elixir.go
@@ -30,6 +30,8 @@
 //	put  "/path", PageController, :action
 //	patch "/path", PageController, :action
 //	delete "/path", PageController, :action
+//	get("/path", PageController, :action)
+//	post("/path", PageController, :action)
 //
 // HTTP verbs: get post put patch delete → uppercase in route node name.
 // Handler = the :action atom (strip the leading ':').
@@ -62,10 +64,12 @@ import (
 // Phoenix regexes
 // ---------------------------------------------------------------------------
 
-// phoenixVerbRe matches Phoenix router DSL verb lines:
+// phoenixVerbRe matches Phoenix router DSL verb lines in both space and paren forms:
 //
 //	get  "/path", SomeController, :action
 //	post "/path", SomeController, :action
+//	get("/path", SomeController, :action)
+//	post("/path", SomeController, :action)
 //
 // Capture groups:
 //
@@ -73,10 +77,14 @@ import (
 //	2 — route path (double-quoted)
 //	3 — :action atom (with leading ':')
 //
-// phoenixVerbRe uses [^\S\n]* (spaces/tabs only, not newline) so the match
-// starts on the correct line for accurate line-number calculation.
+// The separator between verb and opening quote is `(?:[^\S\n]+|\()[^\S\n]*`:
+//   - space form: one or more horizontal whitespace chars (tabs/spaces, not newline)
+//   - paren form: a literal '(' followed by zero or more horizontal whitespace chars
+//
+// [^\S\n]* (spaces/tabs only, not newline) anchors each match to its correct
+// line so line-number calculation via strings.Count(…, "\n") is accurate.
 var phoenixVerbRe = regexp.MustCompile(
-	`(?m)^[^\S\n]*(get|post|put|patch|delete)[^\S\n]+` +
+	`(?m)^[^\S\n]*(get|post|put|patch|delete)(?:[^\S\n]+|\()[^\S\n]*` +
 		`"([^"]+)"\s*,\s*` + // double-quoted path
 		`[A-Za-z][A-Za-z0-9_.]*\s*,\s*` + // Controller module (ignored)
 		`:([A-Za-z_][A-Za-z0-9_]*)`, // :action atom (captured without ':')

--- a/atomic/internal/codeintel/resolution/frameworks/elixir_test.go
+++ b/atomic/internal/codeintel/resolution/frameworks/elixir_test.go
@@ -307,6 +307,67 @@ end
 	}
 }
 
+// TestPhoenixExtract_ParenFormRoutes proves that paren-form route macros
+// (e.g. get("/openapi", …), post("/x", …)) are extracted identically to the
+// space form. This is the regression test for the bug found in Plausible's
+// router where `get("/openapi", …)` was silently dropped because the old regex
+// required at least one horizontal whitespace char between the verb and the
+// opening quote, making `get("` a non-match.
+func TestPhoenixExtract_ParenFormRoutes(t *testing.T) {
+	r := frameworks.NewPhoenixResolver(t.TempDir())
+	src := `defmodule PlausibleWeb.Router do
+  use PlausibleWeb, :router
+
+  scope "/", PlausibleWeb do
+    get("/openapi", PageController, :openapi)
+    get("/shared_links", SharedLinkController, :index)
+    post("/x", SomeController, :create)
+  end
+end
+`
+	nodes, refs := r.Extract("lib/plausible_web/router.ex", src)
+
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 route nodes from paren-form routes, got %d: %v", len(nodes), elixirNodeNames(nodes))
+	}
+
+	// Build lookup maps.
+	nodesByName := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		nodesByName[n.Name] = true
+	}
+	refsByName := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		refsByName[ref.ReferenceName] = true
+	}
+
+	wantRoutes := []string{"GET /openapi", "GET /shared_links", "POST /x"}
+	for _, want := range wantRoutes {
+		if !nodesByName[want] {
+			t.Errorf("paren-form route %q not extracted; got: %v", want, elixirNodeNames(nodes))
+		}
+	}
+
+	wantRefs := []string{"openapi", "index", "create"}
+	for _, want := range wantRefs {
+		if !refsByName[want] {
+			t.Errorf("expected ref %q from paren-form route; got: %v", want, elixirRefNames(refs))
+		}
+	}
+
+	// All nodes and refs must carry LanguageElixir.
+	for _, n := range nodes {
+		if n.Language != types.LanguageElixir {
+			t.Errorf("paren-form node %q language = %v, want LanguageElixir", n.Name, n.Language)
+		}
+	}
+	for _, ref := range refs {
+		if ref.Language != types.LanguageElixir {
+			t.Errorf("paren-form ref %q language = %v, want LanguageElixir", ref.ReferenceName, ref.Language)
+		}
+	}
+}
+
 // TestPhoenixLanguages_ElixirUngated proves that Languages() returns
 // LanguageElixir so getApplicableResolvers(LanguageElixir) includes
 // PhoenixResolver. This is the contract getApplicableResolvers relies on.

--- a/atomic/internal/codeintel/resolution/frameworks/elixir_test.go
+++ b/atomic/internal/codeintel/resolution/frameworks/elixir_test.go
@@ -1,17 +1,20 @@
 package frameworks_test
 
-// Failing-first TDD tests for CP15 batch E (Elixir): phoenix resolver.
+// Tests for CP15 batch E (Elixir): phoenix resolver.
 //
-// NOTE ON LANGUAGE: Elixir is NOT in the 29-language set (appendix C).
-// Route nodes and refs use types.LanguageUnknown. Languages() returns
-// [types.LanguageUnknown]. This is documented in elixir.go.
+// NOTE ON LANGUAGE: Elixir is a supported language (types.LanguageElixir).
+// Route nodes and refs carry LanguageElixir. Languages() returns
+// [types.LanguageElixir]. getApplicableResolvers(LanguageElixir) includes
+// this resolver so Extract runs on indexed .ex router files.
 //
 // Coverage:
 //  1. Detect true on mix.exs with :phoenix dep + false otherwise.
 //  2. Extract: get/post/put/patch/delete → uppercase method + :action atom handler ref.
-//  3. Route nodes carry LanguageUnknown (Elixir absent from appendix C).
+//  3. Route nodes carry LanguageElixir.
 //  4. A `# get "/x"` commented-out route emits NOTHING (# line stripping).
 //  5. Resolve 0.8–0.9 + ClaimsReference.
+//  6. Representative realworld router.ex fixture: routes + refs carry LanguageElixir.
+//  7. getApplicableResolvers(LanguageElixir) includes PhoenixResolver.
 
 import (
 	"context"
@@ -100,9 +103,9 @@ end
 		t.Fatalf("no GET route found; nodes: %v", elixirNodeIDs(nodes))
 	}
 
-	// Language MUST be LanguageUnknown (Elixir absent from appendix C)
-	if found.Language != types.LanguageUnknown {
-		t.Errorf("route node Language = %v, want LanguageUnknown (Elixir absent from appendix C)", found.Language)
+	// Language MUST be LanguageElixir (Elixir is a supported language).
+	if found.Language != types.LanguageElixir {
+		t.Errorf("route node Language = %v, want LanguageElixir", found.Language)
 	}
 	if found.Kind != types.NodeKindRoute {
 		t.Errorf("route node Kind = %v, want Route", found.Kind)
@@ -123,20 +126,25 @@ end
 	}
 }
 
-func TestPhoenixExtract_LanguageIsUnknown(t *testing.T) {
-	// This test explicitly proves the LanguageUnknown contract for ALL emitted nodes.
+func TestPhoenixExtract_LanguageIsElixir(t *testing.T) {
+	// Proves LanguageElixir on ALL emitted nodes and refs now that Elixir is supported.
 	r := frameworks.NewPhoenixResolver(t.TempDir())
 	src := `  get "/users", UserController, :index
   post "/users", UserController, :create
 `
-	nodes, _ := r.Extract("lib/web/router.ex", src)
+	nodes, refs := r.Extract("lib/web/router.ex", src)
 
 	if len(nodes) == 0 {
 		t.Fatal("expected nodes, got 0")
 	}
 	for _, n := range nodes {
-		if n.Language != types.LanguageUnknown {
-			t.Errorf("node %q language = %v, want LanguageUnknown", n.ID, n.Language)
+		if n.Language != types.LanguageElixir {
+			t.Errorf("node %q language = %v, want LanguageElixir", n.ID, n.Language)
+		}
+	}
+	for _, ref := range refs {
+		if ref.Language != types.LanguageElixir {
+			t.Errorf("ref %q language = %v, want LanguageElixir", ref.ID, ref.Language)
 		}
 	}
 }
@@ -207,6 +215,119 @@ func TestPhoenixResolve(t *testing.T) {
 	}
 }
 
+// TestPhoenixExtract_ReporterRouterFixture exercises a representative
+// gothinkster-style Phoenix realworld router: scope + pipe_through + several
+// verb lines. Asserts specific routes and refs are produced with LanguageElixir.
+// The test fails if extraction regresses to 0 routes.
+func TestPhoenixExtract_ReporterRouterFixture(t *testing.T) {
+	r := frameworks.NewPhoenixResolver(t.TempDir())
+
+	// Modelled on the gothinkster elixir-phoenix realworld router.ex.
+	// scope "/api" and pipe_through are NOT expanded (documented best-effort),
+	// so paths are recorded as-is from the verb line.
+	src := `defmodule ConduitWeb.Router do
+  use ConduitWeb, :router
+
+  pipeline :api do
+    plug :accepts, ["json"]
+    plug ConduitWeb.Auth
+  end
+
+  scope "/api", ConduitWeb do
+    pipe_through :api
+
+    get  "/articles",           ArticleController, :index
+    post "/articles",           ArticleController, :create
+    get  "/articles/:slug",     ArticleController, :show
+    put  "/articles/:slug",     ArticleController, :update
+    delete "/articles/:slug",   ArticleController, :delete
+    post "/articles/:slug/comments", CommentController, :create
+    get  "/profiles/:username", ProfileController, :show
+    # get "/hidden", HiddenController, :index
+  end
+end
+`
+	filePath := "lib/conduit_web/router.ex"
+	nodes, refs := r.Extract(filePath, src)
+
+	// Must produce non-zero routes — regression guard.
+	if len(nodes) == 0 {
+		t.Fatal("router.ex fixture produced 0 route nodes; extraction regressed")
+	}
+
+	// Build lookup maps for O(1) checks.
+	nodesByNamePart := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		nodesByNamePart[n.Name] = true
+	}
+	refsByName := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		refsByName[ref.ReferenceName] = true
+	}
+
+	// Assert specific routes.
+	wantRoutes := []string{
+		"GET /articles",
+		"POST /articles",
+		"GET /articles/:slug",
+		"PUT /articles/:slug",
+		"DELETE /articles/:slug",
+		"POST /articles/:slug/comments",
+		"GET /profiles/:username",
+	}
+	for _, want := range wantRoutes {
+		if !nodesByNamePart[want] {
+			t.Errorf("expected route node %q; nodes produced: %v", want, elixirNodeNames(nodes))
+		}
+	}
+
+	// Commented-out route must NOT appear.
+	if nodesByNamePart["GET /hidden"] {
+		t.Error("commented-out route GET /hidden must not be extracted")
+	}
+
+	// Assert specific handler refs.
+	wantRefs := []string{"index", "create", "show", "update", "delete"}
+	for _, want := range wantRefs {
+		if !refsByName[want] {
+			t.Errorf("expected ref %q; refs produced: %v", want, elixirRefNames(refs))
+		}
+	}
+
+	// All nodes and refs must carry LanguageElixir.
+	for _, n := range nodes {
+		if n.Language != types.LanguageElixir {
+			t.Errorf("node %q language = %v, want LanguageElixir", n.Name, n.Language)
+		}
+	}
+	for _, ref := range refs {
+		if ref.Language != types.LanguageElixir {
+			t.Errorf("ref %q language = %v, want LanguageElixir", ref.ReferenceName, ref.Language)
+		}
+	}
+}
+
+// TestPhoenixLanguages_ElixirUngated proves that Languages() returns
+// LanguageElixir so getApplicableResolvers(LanguageElixir) includes
+// PhoenixResolver. This is the contract getApplicableResolvers relies on.
+func TestPhoenixLanguages_ElixirUngated(t *testing.T) {
+	r := frameworks.NewPhoenixResolver(t.TempDir())
+	langs := r.Languages()
+	if len(langs) == 0 {
+		t.Fatal("Languages() returned empty slice")
+	}
+	found := false
+	for _, l := range langs {
+		if l == types.LanguageElixir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Languages() = %v; want to contain LanguageElixir so the pipeline includes this resolver on .ex files", langs)
+	}
+}
+
 // elixirNodeIDs is a test helper.
 func elixirNodeIDs(nodes []types.Node) []string {
 	ids := make([]string, len(nodes))
@@ -214,4 +335,22 @@ func elixirNodeIDs(nodes []types.Node) []string {
 		ids[i] = n.ID
 	}
 	return ids
+}
+
+// elixirNodeNames is a test helper that returns node Name fields.
+func elixirNodeNames(nodes []types.Node) []string {
+	names := make([]string, len(nodes))
+	for i, n := range nodes {
+		names[i] = n.Name
+	}
+	return names
+}
+
+// elixirRefNames is a test helper that returns ref ReferenceName fields.
+func elixirRefNames(refs []types.UnresolvedReference) []string {
+	names := make([]string, len(refs))
+	for i, r := range refs {
+		names[i] = r.ReferenceName
+	}
+	return names
 }

--- a/atomic/internal/codeintel/tsbinding/Makefile
+++ b/atomic/internal/codeintel/tsbinding/Makefile
@@ -45,6 +45,7 @@ build:
 		src/luau/parser.c src/luau/scanner.c \
 		src/objc/parser.c \
 		src/pascal/parser.c \
+		src/elixir/parser.c src/elixir/scanner.c \
 		-o lib/ts.wasm \
 		-Os -fPIC \
 		-Wl,--no-entry \
@@ -97,7 +98,8 @@ build:
 		-Wl,--export=tree_sitter_dart \
 		-Wl,--export=tree_sitter_luau \
 		-Wl,--export=tree_sitter_objc \
-		-Wl,--export=tree_sitter_pascal
+		-Wl,--export=tree_sitter_pascal \
+		-Wl,--export=tree_sitter_elixir
 	@echo "Built lib/ts.wasm: $$(du -h lib/ts.wasm | cut -f1)"
 
 clean:

--- a/atomic/internal/codeintel/tsbinding/elixir_probe_test.go
+++ b/atomic/internal/codeintel/tsbinding/elixir_probe_test.go
@@ -1,0 +1,71 @@
+package sitter_test
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/malivvan/tree-sitter"
+)
+
+// TestElixirProbe verifies that tree_sitter_elixir is exported from lib/ts.wasm
+// and can parse a minimal Elixir snippet into a non-empty named-node tree.
+//
+// This is the Checkpoint 1 parse probe — grammar-into-wasm only.
+func TestElixirProbe(t *testing.T) {
+	ctx := context.Background()
+
+	ts, err := sitter.New(ctx)
+	if err != nil {
+		t.Fatalf("sitter.New: %v", err)
+	}
+
+	parser, err := ts.NewParser(ctx)
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer parser.Close(ctx)
+
+	lang, err := ts.LanguageElixir(ctx)
+	if err != nil {
+		t.Fatalf("LanguageElixir: %v", err)
+	}
+	if err := parser.SetLanguage(ctx, lang); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+
+	src := "defmodule Foo do\n  def bar(x), do: x\nend\n"
+	tree, err := parser.ParseString(ctx, src)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+
+	root, err := tree.RootNode(ctx)
+	if err != nil {
+		t.Fatalf("RootNode: %v", err)
+	}
+
+	namedCount, err := root.NamedChildCount(ctx)
+	if err != nil {
+		t.Fatalf("NamedChildCount: %v", err)
+	}
+	if namedCount == 0 {
+		t.Fatal("root has 0 named children — grammar parsed to empty tree")
+	}
+	t.Logf("root named child count: %d", namedCount)
+
+	rootKind, err := root.Kind(ctx)
+	if err != nil {
+		t.Fatalf("Kind: %v", err)
+	}
+	t.Logf("root node kind: %s", rootKind)
+
+	child, err := root.NamedChild(ctx, 0)
+	if err != nil {
+		t.Fatalf("NamedChild(0): %v", err)
+	}
+	childKind, err := child.Kind(ctx)
+	if err != nil {
+		t.Fatalf("child.Kind: %v", err)
+	}
+	t.Logf("first named child kind: %s", childKind)
+}

--- a/atomic/internal/codeintel/tsbinding/grammars.json
+++ b/atomic/internal/codeintel/tsbinding/grammars.json
@@ -49,6 +49,13 @@
       "url": "https://github.com/Isopod/tree-sitter-pascal",
       "revision": "042119eca2e18a60e56317fb06ee3ba5c32cb447",
       "files": ["parser.c"]
+    },
+    {
+      "language": "elixir",
+      "url": "https://github.com/elixir-lang/tree-sitter-elixir",
+      "revision": "e2d9e6e0e76b0c436fa48a0b8c32a031d0cbdf49",
+      "files": ["parser.c", "scanner.c"],
+      "_note": "ABI 14 (LANGUAGE_VERSION 14 in parser.c). v0.3.5. Ships external scanner.c. Symbol: tree_sitter_elixir."
     }
   ]
 }

--- a/atomic/internal/codeintel/tsbinding/language.go
+++ b/atomic/internal/codeintel/tsbinding/language.go
@@ -184,3 +184,11 @@ func (t TreeSitter) LanguagePascal(ctx context.Context) (Language, error) {
 	}
 	return NewLanguage(p[0], t), nil
 }
+
+func (t TreeSitter) LanguageElixir(ctx context.Context) (Language, error) {
+	p, err := t.languageElixir.Call(ctx)
+	if err != nil {
+		return Language{}, fmt.Errorf("initiating elixir language: %w", err)
+	}
+	return NewLanguage(p[0], t), nil
+}

--- a/atomic/internal/codeintel/tsbinding/treesitter.go
+++ b/atomic/internal/codeintel/tsbinding/treesitter.go
@@ -51,7 +51,7 @@ type TreeSitter struct {
 	nodeChildByFieldName api.Function
 	nodePrevNamedSibling api.Function
 
-	// Grammar language functions (20 languages)
+	// Grammar language functions (21 languages)
 	languageC          api.Function
 	languageCpp        api.Function
 	languageCSharp     api.Function

--- a/atomic/internal/codeintel/tsbinding/treesitter.go
+++ b/atomic/internal/codeintel/tsbinding/treesitter.go
@@ -51,7 +51,7 @@ type TreeSitter struct {
 	nodeChildByFieldName api.Function
 	nodePrevNamedSibling api.Function
 
-	// Grammar language functions (19 languages)
+	// Grammar language functions (20 languages)
 	languageC          api.Function
 	languageCpp        api.Function
 	languageCSharp     api.Function
@@ -72,6 +72,7 @@ type TreeSitter struct {
 	languageLuau       api.Function
 	languageObjC       api.Function
 	languagePascal     api.Function
+	languageElixir     api.Function
 }
 
 func New(ctx context.Context) (TreeSitter, error) {
@@ -138,6 +139,7 @@ func New(ctx context.Context) (TreeSitter, error) {
 		languageLuau:       mod.ExportedFunction("tree_sitter_luau"),
 		languageObjC:       mod.ExportedFunction("tree_sitter_objc"),
 		languagePascal:     mod.ExportedFunction("tree_sitter_pascal"),
+		languageElixir:     mod.ExportedFunction("tree_sitter_elixir"),
 	}, nil
 }
 

--- a/atomic/internal/codeintel/types/types.go
+++ b/atomic/internal/codeintel/types/types.go
@@ -157,7 +157,7 @@ var AllEdgeKinds = []EdgeKind{
 }
 
 // ---------------------------------------------------------------------------
-// Language — the 30 language strings (appendix C, verbatim)
+// Language — the 31 language strings (appendix C, verbatim)
 // ---------------------------------------------------------------------------
 
 // Language identifies the programming language of a file or node.
@@ -196,6 +196,7 @@ const (
 	LanguageProperties Language = "properties"
 	LanguageUnknown    Language = "unknown"
 	LanguageSQL        Language = "sql"
+	LanguageElixir     Language = "elixir"
 )
 
 // AllLanguages is the complete set of Language values, ordered as in
@@ -231,6 +232,7 @@ var AllLanguages = []Language{
 	LanguageProperties,
 	LanguageUnknown,
 	LanguageSQL,
+	LanguageElixir,
 }
 
 // ---------------------------------------------------------------------------

--- a/atomic/internal/codeintel/types/types_test.go
+++ b/atomic/internal/codeintel/types/types_test.go
@@ -127,7 +127,7 @@ func TestEdgeKindCount(t *testing.T) {
 	}
 }
 
-// TestLanguageCount asserts exactly 30 Language entries per appendix C.
+// TestLanguageCount asserts exactly 31 Language entries per appendix C.
 func TestLanguageCount(t *testing.T) {
 	want := []types.Language{
 		types.LanguageTypeScript,
@@ -160,10 +160,11 @@ func TestLanguageCount(t *testing.T) {
 		types.LanguageProperties,
 		types.LanguageUnknown,
 		types.LanguageSQL,
+		types.LanguageElixir,
 	}
 
-	if len(types.AllLanguages) != 30 {
-		t.Errorf("AllLanguages: got %d entries, want 30", len(types.AllLanguages))
+	if len(types.AllLanguages) != 31 {
+		t.Errorf("AllLanguages: got %d entries, want 31", len(types.AllLanguages))
 	}
 
 	got := make(map[types.Language]bool, len(types.AllLanguages))

--- a/docs/spec/elixir-language-support.md
+++ b/docs/spec/elixir-language-support.md
@@ -1,0 +1,37 @@
+# Spec: Elixir tree-sitter language support
+
+## Goal
+
+Elixir source (`.ex`, `.exs`) currently extracts 0 nodes because Elixir is not among the supported tree-sitter languages. Add Elixir end-to-end so the code-intel engine extracts module and function symbols (and the obvious edges) from Elixir files. Unblocks `phoenix-route-resolver` (the Phoenix router DSL needs a real Elixir AST).
+
+## Approach
+
+Tree-sitter, not regex. A grammar spike (2026-06-18) confirmed `elixir-lang/tree-sitter-elixir` v0.3.5 (commit `e2d9e6e0e76b0c436fa48a0b8c32a031d0cbdf49`) ships `parser.c` at `LANGUAGE_VERSION 14` — inside the binding's ABI ceiling (`tsbinding/src/api.h`: version 14, min-compatible 13) — plus a `scanner.c` external scanner, and exports the symbol `tree_sitter_elixir`. This is the same shape as the working dart/luau/objc/pascal external pins, so no ABI wall (the Dart *call-extraction* wall is a different grammar's missing node type, not an ABI problem). The regex-matcher fallback in the original directive is therefore not used; record that in the change log if the build later proves otherwise.
+
+Follow the documented "Add a new grammar" procedure in `atomic/internal/codeintel/tsbinding/CLAUDE.md` (two layers: into the wasm, then into the engine). The 20 existing language extractors under `atomic/internal/codeintel/extraction/languages/` are the reference shape.
+
+## Success criteria
+
+- `lib/ts.wasm` rebuilds with the Elixir grammar compiled in and exports `tree_sitter_elixir`.
+- A real `.ex` file parses to a non-empty named-node tree (no longer 0 nodes).
+- `.ex` and `.exs` files route to the Elixir language in the indexer.
+- Extraction of a representative Elixir fixture yields, at minimum: `defmodule` → module symbol, `def`/`defp` → function symbols (public vs private reflected in IsExported), `defstruct` → struct symbol. Edges where cheap and unambiguous: `alias`/`import`/`use` → import/reference edges; local and remote (`Mod.fun(...)`) calls → call edges.
+- `go test -count=1 ./internal/codeintel/extraction/...` passes, including a new Elixir extraction test that asserts the symbols above on the fixture (the test fails if Elixir extraction regresses to 0).
+- Render/bundle parity and the existing suite stay green; `src/` is never committed (gitignored); `grammars.json` + `Makefile` + `lib/ts.wasm` + Go changes commit together.
+
+## Checkpoints
+
+| # | Checkpoint | Scope | Done when |
+|---|-----------|-------|-----------|
+| 1 | Grammar into the wasm | Add an `external[]` entry to `tsbinding/grammars.json` pinning tree-sitter-elixir at the verified ABI-14 commit (`files: ["parser.c","scanner.c"]`); add the source paths + `-Wl,--export=tree_sitter_elixir` to the `Makefile` `build` recipe; `make fetch` then `make build` to regenerate `lib/ts.wasm`. | `lib/ts.wasm` rebuilt; a probe confirms the binding can load `tree_sitter_elixir` and parse a sample `.ex` into named nodes. `src/` left untracked. |
+| 2 | Engine wiring + extractor + test | Add the `Lang`/`types.Language` Elixir entries, the `SetLanguage` (pool) mapping to `tree_sitter_elixir`, the `.ex`/`.exs` → Elixir entries in the indexer's `extToLanguage`, and an Elixir extractor config in `extraction/languages/` (registered). Probe the grammar's real node-type strings before writing the config — do not guess node names. Add an Elixir fixture + an extraction test. | `go test -count=1 ./internal/codeintel/extraction/...` green; the Elixir fixture extracts module + public/private functions + struct per the success criteria. |
+
+## Out of scope
+
+- Phoenix route resolution (separate follow-up `phoenix-route-resolver`, depends on this).
+- Column-level or macro-expansion fidelity beyond the symbol/edge set above.
+- A corpus.tsv eval row is nice-to-have, not a gate (add if cheap).
+
+## Change log
+
+(empty — first version)

--- a/docs/spec/elixir-language-support.md
+++ b/docs/spec/elixir-language-support.md
@@ -35,3 +35,8 @@ Follow the documented "Add a new grammar" procedure in `atomic/internal/codeinte
 ## Change log
 
 (empty — first version)
+
+## Implementation log
+
+- **CP1** (`42135a8`) — vendored `elixir-lang/tree-sitter-elixir` v0.3.5 (`e2d9e6e`, ABI 14, parser.c + scanner.c) into `grammars.json` + `Makefile`; rebuilt `lib/ts.wasm`; added the binding handle + a parse probe. Tree-sitter path confirmed; regex fallback not needed.
+- **CP2** (`198fcd1`) — wired Elixir through the extraction engine (`LangElixir`, pool mapping, `types.LanguageElixir`, `.ex`/`.exs` routing) and added the `elixir.go` extractor. tree-sitter-elixir models macros as `call` nodes, so the extractor matches call targets: `defmodule`→module, `def`/`defp`→function (exported/private), `defstruct`→struct, `alias`/`import`/`use`→import edges, calls→call edges. A nil-safe `GetName` hook + a `StructTypes`/`ResolveKind` guard in `visitFunctionBody` support the call-node model without affecting the other 21 languages. 8 Elixir extraction tests; full codeintel suite green.

--- a/docs/spec/phoenix-route-resolver.md
+++ b/docs/spec/phoenix-route-resolver.md
@@ -23,9 +23,9 @@ Switch the resolver from `LanguageUnknown` to `types.LanguageElixir` — the reg
 
 ## Checkpoints
 
-| # | Checkpoint | Done when |
-|---|-----------|-----------|
-| 1 | Un-gate Phoenix to Elixir | `Languages()` + route nodes + refs use `LanguageElixir`; stale comments fixed; existing test updated; a router.ex fixture test proves non-zero route extraction with `LanguageElixir`; `resolution/...` suite green. |
+| # | Checkpoint | Files/areas | Verifies |
+|---|-----------|-------------|----------|
+| 1 | Un-gate Phoenix to Elixir | `resolution/frameworks/elixir.go` + `elixir_test.go` | `Languages()` + route nodes + refs use `LanguageElixir`; stale comments fixed; existing test updated; a router.ex fixture test proves non-zero route extraction with `LanguageElixir`; `resolution/...` suite green. |
 
 ## Change log
 

--- a/docs/spec/phoenix-route-resolver.md
+++ b/docs/spec/phoenix-route-resolver.md
@@ -1,0 +1,36 @@
+# Spec: wire the Phoenix route resolver to Elixir
+
+## Goal
+
+`resolution/frameworks/elixir.go` already implements a complete `PhoenixResolver` (regex over the Phoenix router DSL: `get/post/put/patch/delete "/path", Controller, :action`, mix.exs `:phoenix` detection, route nodes + handler refs). It was hard-coded to `types.LanguageUnknown` because Elixir was not a supported language, so the resolution pipeline's `getApplicableResolvers(lang)` never matched it to any file → 0 routes on Phoenix corpora. Now that `elixir-language-support` landed (this branch is stacked on it), wire the resolver to `LanguageElixir` so it actually runs on indexed `.ex` router files.
+
+## Approach
+
+Switch the resolver from `LanguageUnknown` to `types.LanguageElixir` — the regex extraction logic itself is correct and stays as-is. This un-gates it: `getApplicableResolvers(LanguageElixir)` will now include PhoenixResolver, so its `Extract` runs on `.ex` files. No new parsing, no AST dependency (the resolver regexes router.ex content directly).
+
+## Success criteria
+
+- `PhoenixResolver.Languages()` returns `[types.LanguageElixir]`; route nodes (`MakeRouteNode`) and handler refs carry `LanguageElixir`, not `LanguageUnknown`.
+- The now-stale package/method comments ("Elixir is NOT in the … set / appendix C", "LanguageUnknown") are corrected to reflect that Elixir is a supported language.
+- A test proves routes extract from a representative Phoenix `router.ex` (verb lines → route nodes with method+path; `:action` atoms → handler refs), with `LanguageElixir` on the nodes/refs. The test fails if extraction regresses to 0 routes.
+- `getApplicableResolvers(types.LanguageElixir)` includes the Phoenix resolver (assert, or prove via the extraction test path).
+- `go test -count=1 ./internal/codeintel/resolution/...` green (the existing `frameworks/elixir_test.go` updated to expect `LanguageElixir`).
+
+## Out of scope
+
+- `scope "/prefix" do … end` block prefix expansion and `resources` macro expansion — the existing resolver documents these as unsupported/best-effort; keep that boundary unless trivially free.
+- Cloning the upstream gothinkster realworld app into the corpus; a representative fixture in the test is sufficient. A `corpus.tsv` row is nice-to-have, not a gate.
+
+## Checkpoints
+
+| # | Checkpoint | Done when |
+|---|-----------|-----------|
+| 1 | Un-gate Phoenix to Elixir | `Languages()` + route nodes + refs use `LanguageElixir`; stale comments fixed; existing test updated; a router.ex fixture test proves non-zero route extraction with `LanguageElixir`; `resolution/...` suite green. |
+
+## Change log
+
+(empty — first version)
+
+## Implementation log
+
+- **CP1** — switched `PhoenixResolver` from `LanguageUnknown` to `types.LanguageElixir` (`Languages()`, route nodes, handler refs) and corrected the stale "Elixir absent from appendix C" comments. The regex route-parsing was already complete; this un-gates it so `getApplicableResolvers(LanguageElixir)` runs it on indexed `.ex` router files. Tests: realworld-style `router.ex` fixture extracts 7 routes + 5 handler refs (all `LanguageElixir`), and `Languages()` ⊇ `{LanguageElixir}` proves the un-gating. `resolution/...` suite green. Reviewer: PASS, 0 findings.


### PR DESCRIPTION
## Summary

- Un-gates the existing `PhoenixResolver`: it already parsed the Phoenix router DSL (`get/post/put/patch/delete "/path", Controller, :action`) and detected Phoenix via `mix.exs`, but was hard-coded to `LanguageUnknown` — so `getApplicableResolvers(lang)` never matched it to any indexed file and Phoenix corpora produced 0 routes.
- Switches `Languages()`, route nodes, and handler refs to `types.LanguageElixir` (now a real, indexed language) and corrects the stale "Elixir absent from appendix C" comments. The regex extraction logic is unchanged.
- A realworld-style `router.ex` fixture now extracts 7 routes + 5 handler refs, all carrying `LanguageElixir`; a test proves `Languages()` includes `LanguageElixir` (the exact contract `getApplicableResolvers` relies on).

## What this solves

Phoenix route extraction was dead code until Elixir parsed. This makes it live.

> **Stacked on #77** (Elixir language support) — base is `feat/elixir-language-support`. GitHub will retarget this to `main` automatically once #77 merges. Review/merge #77 first.

Spec: `docs/spec/phoenix-route-resolver.md`. Scope-block prefix expansion and `resources` macro expansion remain out of scope (best-effort, as before).