### PR TITLE
feat(codeintel): wire Phoenix route resolver to Elixir

### DIFF
--- a/atomic/internal/codeintel/resolution/frameworks/elixir.go
+++ b/atomic/internal/codeintel/resolution/frameworks/elixir.go
@@ -3,13 +3,11 @@
 // This file implements one FrameworkResolver + FrameworkExtractor pair for
 // the Phoenix web framework (Elixir).
 //
-// # Language — IMPORTANT
+// # Language
 //
-// Elixir is NOT in the 29-language set (appendix C of the code-intel-engine
-// spec). Route nodes and handler refs use types.LanguageUnknown. Languages()
-// returns [types.LanguageUnknown]. ClaimsReference and Resolve are implemented
-// for contract completeness even though no Elixir-language refs come from
-// extraction.
+// Elixir is a supported language (types.LanguageElixir). Route nodes and
+// handler refs carry LanguageElixir. Languages() returns [types.LanguageElixir]
+// so getApplicableResolvers includes this resolver when indexing .ex files.
 //
 // # Comment stripping
 //
@@ -32,6 +30,8 @@
 //	put  "/path", PageController, :action
 //	patch "/path", PageController, :action
 //	delete "/path", PageController, :action
+//	get("/path", PageController, :action)
+//	post("/path", PageController, :action)
 //
 // HTTP verbs: get post put patch delete → uppercase in route node name.
 // Handler = the :action atom (strip the leading ':').
@@ -64,10 +64,12 @@ import (
 // Phoenix regexes
 // ---------------------------------------------------------------------------
 
-// phoenixVerbRe matches Phoenix router DSL verb lines:
+// phoenixVerbRe matches Phoenix router DSL verb lines in both space and paren forms:
 //
 //	get  "/path", SomeController, :action
 //	post "/path", SomeController, :action
+//	get("/path", SomeController, :action)
+//	post("/path", SomeController, :action)
 //
 // Capture groups:
 //
@@ -75,10 +77,14 @@ import (
 //	2 — route path (double-quoted)
 //	3 — :action atom (with leading ':')
 //
-// phoenixVerbRe uses [^\S\n]* (spaces/tabs only, not newline) so the match
-// starts on the correct line for accurate line-number calculation.
+// The separator between verb and opening quote is `(?:[^\S\n]+|\()[^\S\n]*`:
+//   - space form: one or more horizontal whitespace chars (tabs/spaces, not newline)
+//   - paren form: a literal '(' followed by zero or more horizontal whitespace chars
+//
+// [^\S\n]* (spaces/tabs only, not newline) anchors each match to its correct
+// line so line-number calculation via strings.Count(…, "\n") is accurate.
 var phoenixVerbRe = regexp.MustCompile(
-	`(?m)^[^\S\n]*(get|post|put|patch|delete)[^\S\n]+` +
+	`(?m)^[^\S\n]*(get|post|put|patch|delete)(?:[^\S\n]+|\()[^\S\n]*` +
 		`"([^"]+)"\s*,\s*` + // double-quoted path
 		`[A-Za-z][A-Za-z0-9_.]*\s*,\s*` + // Controller module (ignored)
 		`:([A-Za-z_][A-Za-z0-9_]*)`, // :action atom (captured without ':')
@@ -89,9 +95,7 @@ var phoenixVerbRe = regexp.MustCompile(
 // ---------------------------------------------------------------------------
 
 // PhoenixResolver implements FrameworkResolver + FrameworkExtractor for Phoenix.
-//
-// NOTE: Elixir is absent from the 29-language set (appendix C). All route
-// nodes and refs use types.LanguageUnknown. See package doc.
+// Route nodes and refs carry LanguageElixir. See package doc.
 type PhoenixResolver struct {
 	projectRoot string
 	claimed     map[string]bool
@@ -105,10 +109,10 @@ func NewPhoenixResolver(projectRoot string) *PhoenixResolver {
 // Name returns "phoenix".
 func (r *PhoenixResolver) Name() string { return "phoenix" }
 
-// Languages returns [LanguageUnknown] because Elixir is not in the 29-language
-// set (appendix C). Route nodes and refs use LanguageUnknown for the same reason.
+// Languages returns [LanguageElixir]. The pipeline's getApplicableResolvers
+// matches this resolver to .ex files so Extract runs on Phoenix router files.
 func (r *PhoenixResolver) Languages() []types.Language {
-	return []types.Language{types.LanguageUnknown}
+	return []types.Language{types.LanguageElixir}
 }
 
 // Detect returns true when mix.exs in projectRoot contains `:phoenix` as a
@@ -124,7 +128,7 @@ func (r *PhoenixResolver) Detect(ctx context.Context) bool {
 // Extract scans filePath/content for Phoenix router verb lines and returns
 // route nodes + handler refs. # line comments are stripped first.
 //
-// Route nodes carry LanguageUnknown (Elixir absent from appendix C).
+// Route nodes and refs carry LanguageElixir.
 func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []types.UnresolvedReference) {
 	stripped := stripHashLineComments(content)
 	totalLines := strings.Count(content, "\n") + 1
@@ -145,8 +149,7 @@ func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []typ
 			line = totalLines
 		}
 
-		// LanguageUnknown: Elixir is not in the 29-language set (appendix C).
-		node := MakeRouteNode(filePath, line, verb, routePath, types.LanguageUnknown)
+		node := MakeRouteNode(filePath, line, verb, routePath, types.LanguageElixir)
 		nodes = append(nodes, node)
 
 		if action != "" {
@@ -158,7 +161,7 @@ func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []typ
 				ReferenceKind: types.EdgeKindReferences,
 				Line:          line,
 				FilePath:      filePath,
-				Language:      types.LanguageUnknown,
+				Language:      types.LanguageElixir,
 			})
 		}
 	}
@@ -170,8 +173,6 @@ func (r *PhoenixResolver) Extract(filePath, content string) ([]types.Node, []typ
 func (r *PhoenixResolver) ClaimsReference(name string) bool { return r.claimed[name] }
 
 // Resolve returns confidence 0.85 for claimed action names.
-// Implemented for contract completeness (no Elixir-language refs come from
-// extraction since Elixir is absent from appendix C).
 func (r *PhoenixResolver) Resolve(ctx context.Context, ref types.UnresolvedReference) (resolution.ResolvedRef, error) {
 	if !r.claimed[ref.ReferenceName] {
 		return resolution.ResolvedRef{}, nil

--- a/atomic/internal/codeintel/resolution/frameworks/elixir_test.go
+++ b/atomic/internal/codeintel/resolution/frameworks/elixir_test.go
@@ -1,17 +1,20 @@
 package frameworks_test
 
-// Failing-first TDD tests for CP15 batch E (Elixir): phoenix resolver.
+// Tests for CP15 batch E (Elixir): phoenix resolver.
 //
-// NOTE ON LANGUAGE: Elixir is NOT in the 29-language set (appendix C).
-// Route nodes and refs use types.LanguageUnknown. Languages() returns
-// [types.LanguageUnknown]. This is documented in elixir.go.
+// NOTE ON LANGUAGE: Elixir is a supported language (types.LanguageElixir).
+// Route nodes and refs carry LanguageElixir. Languages() returns
+// [types.LanguageElixir]. getApplicableResolvers(LanguageElixir) includes
+// this resolver so Extract runs on indexed .ex router files.
 //
 // Coverage:
 //  1. Detect true on mix.exs with :phoenix dep + false otherwise.
 //  2. Extract: get/post/put/patch/delete → uppercase method + :action atom handler ref.
-//  3. Route nodes carry LanguageUnknown (Elixir absent from appendix C).
+//  3. Route nodes carry LanguageElixir.
 //  4. A `# get "/x"` commented-out route emits NOTHING (# line stripping).
 //  5. Resolve 0.8–0.9 + ClaimsReference.
+//  6. Representative realworld router.ex fixture: routes + refs carry LanguageElixir.
+//  7. getApplicableResolvers(LanguageElixir) includes PhoenixResolver.
 
 import (
 	"context"
@@ -100,9 +103,9 @@ end
 		t.Fatalf("no GET route found; nodes: %v", elixirNodeIDs(nodes))
 	}
 
-	// Language MUST be LanguageUnknown (Elixir absent from appendix C)
-	if found.Language != types.LanguageUnknown {
-		t.Errorf("route node Language = %v, want LanguageUnknown (Elixir absent from appendix C)", found.Language)
+	// Language MUST be LanguageElixir (Elixir is a supported language).
+	if found.Language != types.LanguageElixir {
+		t.Errorf("route node Language = %v, want LanguageElixir", found.Language)
 	}
 	if found.Kind != types.NodeKindRoute {
 		t.Errorf("route node Kind = %v, want Route", found.Kind)
@@ -123,20 +126,25 @@ end
 	}
 }
 
-func TestPhoenixExtract_LanguageIsUnknown(t *testing.T) {
-	// This test explicitly proves the LanguageUnknown contract for ALL emitted nodes.
+func TestPhoenixExtract_LanguageIsElixir(t *testing.T) {
+	// Proves LanguageElixir on ALL emitted nodes and refs now that Elixir is supported.
 	r := frameworks.NewPhoenixResolver(t.TempDir())
 	src := `  get "/users", UserController, :index
   post "/users", UserController, :create
 `
-	nodes, _ := r.Extract("lib/web/router.ex", src)
+	nodes, refs := r.Extract("lib/web/router.ex", src)
 
 	if len(nodes) == 0 {
 		t.Fatal("expected nodes, got 0")
 	}
 	for _, n := range nodes {
-		if n.Language != types.LanguageUnknown {
-			t.Errorf("node %q language = %v, want LanguageUnknown", n.ID, n.Language)
+		if n.Language != types.LanguageElixir {
+			t.Errorf("node %q language = %v, want LanguageElixir", n.ID, n.Language)
+		}
+	}
+	for _, ref := range refs {
+		if ref.Language != types.LanguageElixir {
+			t.Errorf("ref %q language = %v, want LanguageElixir", ref.ID, ref.Language)
 		}
 	}
 }
@@ -207,6 +215,180 @@ func TestPhoenixResolve(t *testing.T) {
 	}
 }
 
+// TestPhoenixExtract_ReporterRouterFixture exercises a representative
+// gothinkster-style Phoenix realworld router: scope + pipe_through + several
+// verb lines. Asserts specific routes and refs are produced with LanguageElixir.
+// The test fails if extraction regresses to 0 routes.
+func TestPhoenixExtract_ReporterRouterFixture(t *testing.T) {
+	r := frameworks.NewPhoenixResolver(t.TempDir())
+
+	// Modelled on the gothinkster elixir-phoenix realworld router.ex.
+	// scope "/api" and pipe_through are NOT expanded (documented best-effort),
+	// so paths are recorded as-is from the verb line.
+	src := `defmodule ConduitWeb.Router do
+  use ConduitWeb, :router
+
+  pipeline :api do
+    plug :accepts, ["json"]
+    plug ConduitWeb.Auth
+  end
+
+  scope "/api", ConduitWeb do
+    pipe_through :api
+
+    get  "/articles",           ArticleController, :index
+    post "/articles",           ArticleController, :create
+    get  "/articles/:slug",     ArticleController, :show
+    put  "/articles/:slug",     ArticleController, :update
+    delete "/articles/:slug",   ArticleController, :delete
+    post "/articles/:slug/comments", CommentController, :create
+    get  "/profiles/:username", ProfileController, :show
+    # get "/hidden", HiddenController, :index
+  end
+end
+`
+	filePath := "lib/conduit_web/router.ex"
+	nodes, refs := r.Extract(filePath, src)
+
+	// Must produce non-zero routes — regression guard.
+	if len(nodes) == 0 {
+		t.Fatal("router.ex fixture produced 0 route nodes; extraction regressed")
+	}
+
+	// Build lookup maps for O(1) checks.
+	nodesByNamePart := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		nodesByNamePart[n.Name] = true
+	}
+	refsByName := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		refsByName[ref.ReferenceName] = true
+	}
+
+	// Assert specific routes.
+	wantRoutes := []string{
+		"GET /articles",
+		"POST /articles",
+		"GET /articles/:slug",
+		"PUT /articles/:slug",
+		"DELETE /articles/:slug",
+		"POST /articles/:slug/comments",
+		"GET /profiles/:username",
+	}
+	for _, want := range wantRoutes {
+		if !nodesByNamePart[want] {
+			t.Errorf("expected route node %q; nodes produced: %v", want, elixirNodeNames(nodes))
+		}
+	}
+
+	// Commented-out route must NOT appear.
+	if nodesByNamePart["GET /hidden"] {
+		t.Error("commented-out route GET /hidden must not be extracted")
+	}
+
+	// Assert specific handler refs.
+	wantRefs := []string{"index", "create", "show", "update", "delete"}
+	for _, want := range wantRefs {
+		if !refsByName[want] {
+			t.Errorf("expected ref %q; refs produced: %v", want, elixirRefNames(refs))
+		}
+	}
+
+	// All nodes and refs must carry LanguageElixir.
+	for _, n := range nodes {
+		if n.Language != types.LanguageElixir {
+			t.Errorf("node %q language = %v, want LanguageElixir", n.Name, n.Language)
+		}
+	}
+	for _, ref := range refs {
+		if ref.Language != types.LanguageElixir {
+			t.Errorf("ref %q language = %v, want LanguageElixir", ref.ReferenceName, ref.Language)
+		}
+	}
+}
+
+// TestPhoenixExtract_ParenFormRoutes proves that paren-form route macros
+// (e.g. get("/openapi", …), post("/x", …)) are extracted identically to the
+// space form. This is the regression test for the bug found in Plausible's
+// router where `get("/openapi", …)` was silently dropped because the old regex
+// required at least one horizontal whitespace char between the verb and the
+// opening quote, making `get("` a non-match.
+func TestPhoenixExtract_ParenFormRoutes(t *testing.T) {
+	r := frameworks.NewPhoenixResolver(t.TempDir())
+	src := `defmodule PlausibleWeb.Router do
+  use PlausibleWeb, :router
+
+  scope "/", PlausibleWeb do
+    get("/openapi", PageController, :openapi)
+    get("/shared_links", SharedLinkController, :index)
+    post("/x", SomeController, :create)
+  end
+end
+`
+	nodes, refs := r.Extract("lib/plausible_web/router.ex", src)
+
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 route nodes from paren-form routes, got %d: %v", len(nodes), elixirNodeNames(nodes))
+	}
+
+	// Build lookup maps.
+	nodesByName := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		nodesByName[n.Name] = true
+	}
+	refsByName := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		refsByName[ref.ReferenceName] = true
+	}
+
+	wantRoutes := []string{"GET /openapi", "GET /shared_links", "POST /x"}
+	for _, want := range wantRoutes {
+		if !nodesByName[want] {
+			t.Errorf("paren-form route %q not extracted; got: %v", want, elixirNodeNames(nodes))
+		}
+	}
+
+	wantRefs := []string{"openapi", "index", "create"}
+	for _, want := range wantRefs {
+		if !refsByName[want] {
+			t.Errorf("expected ref %q from paren-form route; got: %v", want, elixirRefNames(refs))
+		}
+	}
+
+	// All nodes and refs must carry LanguageElixir.
+	for _, n := range nodes {
+		if n.Language != types.LanguageElixir {
+			t.Errorf("paren-form node %q language = %v, want LanguageElixir", n.Name, n.Language)
+		}
+	}
+	for _, ref := range refs {
+		if ref.Language != types.LanguageElixir {
+			t.Errorf("paren-form ref %q language = %v, want LanguageElixir", ref.ReferenceName, ref.Language)
+		}
+	}
+}
+
+// TestPhoenixLanguages_ElixirUngated proves that Languages() returns
+// LanguageElixir so getApplicableResolvers(LanguageElixir) includes
+// PhoenixResolver. This is the contract getApplicableResolvers relies on.
+func TestPhoenixLanguages_ElixirUngated(t *testing.T) {
+	r := frameworks.NewPhoenixResolver(t.TempDir())
+	langs := r.Languages()
+	if len(langs) == 0 {
+		t.Fatal("Languages() returned empty slice")
+	}
+	found := false
+	for _, l := range langs {
+		if l == types.LanguageElixir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Languages() = %v; want to contain LanguageElixir so the pipeline includes this resolver on .ex files", langs)
+	}
+}
+
 // elixirNodeIDs is a test helper.
 func elixirNodeIDs(nodes []types.Node) []string {
 	ids := make([]string, len(nodes))
@@ -214,4 +396,22 @@ func elixirNodeIDs(nodes []types.Node) []string {
 		ids[i] = n.ID
 	}
 	return ids
+}
+
+// elixirNodeNames is a test helper that returns node Name fields.
+func elixirNodeNames(nodes []types.Node) []string {
+	names := make([]string, len(nodes))
+	for i, n := range nodes {
+		names[i] = n.Name
+	}
+	return names
+}
+
+// elixirRefNames is a test helper that returns ref ReferenceName fields.
+func elixirRefNames(refs []types.UnresolvedReference) []string {
+	names := make([]string, len(refs))
+	for i, r := range refs {
+		names[i] = r.ReferenceName
+	}
+	return names
 }

--- a/docs/spec/phoenix-route-resolver.md
+++ b/docs/spec/phoenix-route-resolver.md
@@ -1,0 +1,36 @@
+# Spec: wire the Phoenix route resolver to Elixir
+
+## Goal
+
+`resolution/frameworks/elixir.go` already implements a complete `PhoenixResolver` (regex over the Phoenix router DSL: `get/post/put/patch/delete "/path", Controller, :action`, mix.exs `:phoenix` detection, route nodes + handler refs). It was hard-coded to `types.LanguageUnknown` because Elixir was not a supported language, so the resolution pipeline's `getApplicableResolvers(lang)` never matched it to any file → 0 routes on Phoenix corpora. Now that `elixir-language-support` landed (this branch is stacked on it), wire the resolver to `LanguageElixir` so it actually runs on indexed `.ex` router files.
+
+## Approach
+
+Switch the resolver from `LanguageUnknown` to `types.LanguageElixir` — the regex extraction logic itself is correct and stays as-is. This un-gates it: `getApplicableResolvers(LanguageElixir)` will now include PhoenixResolver, so its `Extract` runs on `.ex` files. No new parsing, no AST dependency (the resolver regexes router.ex content directly).
+
+## Success criteria
+
+- `PhoenixResolver.Languages()` returns `[types.LanguageElixir]`; route nodes (`MakeRouteNode`) and handler refs carry `LanguageElixir`, not `LanguageUnknown`.
+- The now-stale package/method comments ("Elixir is NOT in the … set / appendix C", "LanguageUnknown") are corrected to reflect that Elixir is a supported language.
+- A test proves routes extract from a representative Phoenix `router.ex` (verb lines → route nodes with method+path; `:action` atoms → handler refs), with `LanguageElixir` on the nodes/refs. The test fails if extraction regresses to 0 routes.
+- `getApplicableResolvers(types.LanguageElixir)` includes the Phoenix resolver (assert, or prove via the extraction test path).
+- `go test -count=1 ./internal/codeintel/resolution/...` green (the existing `frameworks/elixir_test.go` updated to expect `LanguageElixir`).
+
+## Out of scope
+
+- `scope "/prefix" do … end` block prefix expansion and `resources` macro expansion — the existing resolver documents these as unsupported/best-effort; keep that boundary unless trivially free.
+- Cloning the upstream gothinkster realworld app into the corpus; a representative fixture in the test is sufficient. A `corpus.tsv` row is nice-to-have, not a gate.
+
+## Checkpoints
+
+| # | Checkpoint | Files/areas | Verifies |
+|---|-----------|-------------|----------|
+| 1 | Un-gate Phoenix to Elixir | `resolution/frameworks/elixir.go` + `elixir_test.go` | `Languages()` + route nodes + refs use `LanguageElixir`; stale comments fixed; existing test updated; a router.ex fixture test proves non-zero route extraction with `LanguageElixir`; `resolution/...` suite green. |
+
+## Change log
+
+(empty — first version)
+
+## Implementation log
+
+- **CP1** — switched `PhoenixResolver` from `LanguageUnknown` to `types.LanguageElixir` (`Languages()`, route nodes, handler refs) and corrected the stale "Elixir absent from appendix C" comments. The regex route-parsing was already complete; this un-gates it so `getApplicableResolvers(LanguageElixir)` runs it on indexed `.ex` router files. Tests: realworld-style `router.ex` fixture extracts 7 routes + 5 handler refs (all `LanguageElixir`), and `Languages()` ⊇ `{LanguageElixir}` proves the un-gating. `resolution/...` suite green. Reviewer: PASS, 0 findings.


### PR DESCRIPTION
Recreated from #78 (the original was opened against the stacked Elixir branch, so the PR workflow never triggered; a fresh PR to main runs CI). Content unchanged + extraction-bug fix included.

## Summary
- Un-gates the existing `PhoenixResolver` to `types.LanguageElixir` so it runs on indexed `.ex` router files (was dead on `LanguageUnknown`).
- Fixes paren-form route matching: `get("/x", C, :a)` was silently dropped (regex required whitespace after the verb); now matches both space and paren forms. Verified on Plausible: 207 → 228 routes.

Depends on Elixir support (#77, already merged to main).