### PR TITLE
feat(code-intel): emit calls edge for T-SQL CROSS/OUTER APPLY

### DIFF
--- a/atomic/internal/codeintel/extraction/standalone/sql.go
+++ b/atomic/internal/codeintel/extraction/standalone/sql.go
@@ -368,6 +368,12 @@ var bodyMergeIntoRE = regexp.MustCompile(`(?i)\bMERGE\s+INTO\s+(` + sqlQNameRaw 
 // Group 1 = routine name.
 var bodyExecCallRE = regexp.MustCompile(`(?i)\b(?:EXEC(?:UTE)?\s+|CALL\s+)(` + sqlQNameRaw + `)\s*[\s(]`)
 
+// bodyApplyRE matches CROSS APPLY or OUTER APPLY <tvf>( in a routine/view body.
+// The trailing \s*\( restricts to table-valued-function invocations — a
+// correlated derived-table apply (CROSS APPLY (SELECT ...)) cannot match because
+// sqlQNameRaw requires an identifier, not '('. Group 1 = TVF name.
+var bodyApplyRE = regexp.MustCompile(`(?i)\b(?:CROSS|OUTER)\s+APPLY\s+(` + sqlQNameRaw + `)\s*\(`)
+
 // bodyFlattenRE matches FLATTEN ( [INPUT =>] <expr> ) inside a body scan.
 // F3: used in scanBodyEdges to emit a references edge to <expr> ONLY when
 // <expr> is a single unqualified identifier (no dot). Dotted expressions are
@@ -2479,6 +2485,15 @@ func scanBodyEdges(
 			if stageName != "" {
 				addRef(stageName, types.EdgeKindReferences, m[4])
 			}
+		}
+	}
+
+	// CROSS APPLY / OUTER APPLY <tvf>( → calls
+	for _, m := range bodyApplyRE.FindAllStringSubmatchIndex(body, -1) {
+		rawName := body[m[2]:m[3]]
+		_, name := parseQName(rawName)
+		if name != "" {
+			addRef(name, types.EdgeKindCalls, m[2])
 		}
 	}
 

--- a/atomic/internal/codeintel/extraction/standalone/sql_test.go
+++ b/atomic/internal/codeintel/extraction/standalone/sql_test.go
@@ -3465,3 +3465,198 @@ func TestF4CopyInsideTaskNotScript(t *testing.T) {
 		t.Error("task node must own references edge to 'stg' (COPY INTO inside task body)")
 	}
 }
+
+// TestTSQLCrossApplyCalls verifies that CROSS APPLY <tvf>(...) in a T-SQL
+// procedure body emits a calls edge to the invoked table-valued function.
+// WHY (issue #70): APPLY is the canonical T-SQL idiom for correlated TVF joins.
+// Without this, proc→TVF lineage is invisible to the code-intel graph.
+const tsqlCrossApplyFixture = `
+CREATE TABLE [dbo].[Orders] ([OrderId] INT);
+CREATE FUNCTION [dbo].[GetLines](@id INT) RETURNS TABLE AS RETURN SELECT 1 AS x;
+CREATE PROCEDURE [dbo].[ProcessOrders]
+AS
+BEGIN
+  SELECT o.OrderId, l.x
+  FROM [dbo].[Orders] o
+  CROSS APPLY [dbo].[GetLines](o.OrderId) l;
+END;
+GO
+`
+
+func TestTSQLCrossApplyCalls(t *testing.T) {
+	// criterion 1: CROSS APPLY <tvf>(...) → calls edge to bare function name
+	ext := newSQL()
+	result, err := ext.Extract("/db/tsql_cross_apply.sql", tsqlCrossApplyFixture)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	refs := result.UnresolvedReferences
+
+	// GetLines is CROSS APPLY target → calls
+	if !hasUnresolvedRef(refs, "GetLines", types.EdgeKindCalls) {
+		t.Error("expected calls edge to 'GetLines' from CROSS APPLY [dbo].[GetLines](...)")
+	}
+	// Orders is also referenced in FROM → references (criterion 4 combined check)
+	if !hasUnresolvedRef(refs, "Orders", types.EdgeKindReferences) {
+		t.Error("expected references edge to 'Orders' from FROM clause alongside CROSS APPLY")
+	}
+}
+
+// TestTSQLOuterApplyCalls verifies that OUTER APPLY <tvf>(...) also emits a
+// calls edge — both flavors must be covered.
+// WHY (criterion 2): OUTER APPLY is a left-join variant; same lineage semantics.
+const tsqlOuterApplyFixture = `
+CREATE TABLE [dbo].[Tags] ([TagId] INT);
+CREATE FUNCTION [dbo].[GetTags](@id INT) RETURNS TABLE AS RETURN SELECT 1 AS x;
+CREATE PROCEDURE [dbo].[ReadTags]
+AS
+BEGIN
+  SELECT t.TagId, g.x
+  FROM [dbo].[Tags] t
+  OUTER APPLY [dbo].[GetTags](t.TagId) g;
+END;
+GO
+`
+
+func TestTSQLOuterApplyCalls(t *testing.T) {
+	// criterion 2: OUTER APPLY <tvf>(...) → calls edge
+	ext := newSQL()
+	result, err := ext.Extract("/db/tsql_outer_apply.sql", tsqlOuterApplyFixture)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	refs := result.UnresolvedReferences
+
+	// GetTags is OUTER APPLY target → calls
+	if !hasUnresolvedRef(refs, "GetTags", types.EdgeKindCalls) {
+		t.Error("expected calls edge to 'GetTags' from OUTER APPLY [dbo].[GetTags](...)")
+	}
+}
+
+// TestTSQLApplySchemaStripped verifies that a schema-qualified APPLY target
+// emits a calls edge to the bare function name with schema stripped.
+// WHY (criterion 3): parseQName strips schema prefix so all edges match the
+// node's unqualified name — consistent with every other body edge kind.
+const tsqlApplySchemaFixture = `
+CREATE SCHEMA analytics;
+CREATE FUNCTION analytics.fn_rollup(@x INT) RETURNS TABLE AS RETURN SELECT 1 AS v;
+CREATE PROCEDURE dbo.Run
+AS
+BEGIN
+  SELECT v FROM analytics.fn_rollup(1) r
+  CROSS APPLY analytics.fn_rollup(r.v) q;
+END;
+GO
+`
+
+func TestTSQLApplySchemaStripped(t *testing.T) {
+	// criterion 3: schema-qualified target → calls edge to bare name
+	ext := newSQL()
+	result, err := ext.Extract("/db/tsql_apply_schema.sql", tsqlApplySchemaFixture)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	refs := result.UnresolvedReferences
+
+	// fn_rollup is the bare name after parseQName strips "analytics."
+	if !hasUnresolvedRef(refs, "fn_rollup", types.EdgeKindCalls) {
+		t.Error("expected calls edge to 'fn_rollup' with schema stripped from CROSS APPLY analytics.fn_rollup(...)")
+	}
+	// no edge to the schema prefix itself
+	if countUnresolvedRefs(refs, "analytics") > 0 {
+		t.Error("schema prefix 'analytics' must not appear as a ref target")
+	}
+}
+
+// TestTSQLApplyKeywordsNotEdges verifies that CROSS, OUTER, and APPLY never
+// appear as reference or call targets.
+// WHY (criterion 5): bodyApplyRE captures only the identifier after APPLY and
+// before '(' — the CROSS/OUTER/APPLY keywords themselves are never in group 1.
+// The fixture uses valid T-SQL: a table source precedes CROSS/OUTER APPLY.
+const tsqlApplyKeywordsFixture = `
+CREATE TABLE dbo.items (id INT);
+CREATE FUNCTION dbo.fn(@x INT) RETURNS TABLE AS RETURN SELECT 1 AS v;
+CREATE PROCEDURE dbo.P
+AS
+BEGIN
+  SELECT v
+  FROM dbo.items i
+  CROSS APPLY dbo.fn(i.id) x
+  UNION ALL
+  SELECT v
+  FROM dbo.items i
+  OUTER APPLY dbo.fn(i.id) y;
+END;
+GO
+`
+
+func TestTSQLApplyKeywordsNotEdges(t *testing.T) {
+	// criterion 5: CROSS / OUTER / APPLY are never reference or call targets
+	ext := newSQL()
+	result, err := ext.Extract("/db/tsql_apply_kw.sql", tsqlApplyKeywordsFixture)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	refs := result.UnresolvedReferences
+
+	for _, kw := range []string{"CROSS", "cross", "OUTER", "outer", "APPLY", "apply"} {
+		if countUnresolvedRefs(refs, kw) > 0 {
+			t.Errorf("keyword %q must not appear as a ref target", kw)
+		}
+	}
+	// fn IS a real TVF → should get a calls edge
+	if !hasUnresolvedRef(refs, "fn", types.EdgeKindCalls) {
+		t.Error("expected calls edge to 'fn' from CROSS APPLY dbo.fn(...)")
+	}
+}
+
+// TestTSQLApplyDerivedTableNoCallEdge verifies that a correlated derived-table
+// apply (FROM dbo.src s CROSS APPLY (SELECT col FROM real_inner) sub) does NOT
+// emit an APPLY-derived calls edge to the subquery alias, but the inner
+// FROM real_inner still emits a references edge and the left source dbo.src
+// emits a references edge.
+// WHY (criterion 6): bodyApplyRE requires a sqlQNameRaw identifier immediately
+// after APPLY, followed by '('. A derived-table apply starts with '(' after
+// APPLY — not an identifier — so the regex cannot match. The inner FROM clause
+// is caught by the existing viewBodyFROMRE scan, preserving that lineage.
+const tsqlApplyDerivedTableFixture = `
+CREATE TABLE dbo.src (id INT);
+CREATE TABLE dbo.real_inner (col INT);
+CREATE PROCEDURE dbo.Q
+AS
+BEGIN
+  SELECT s.id, sub.col
+  FROM dbo.src s
+  CROSS APPLY (SELECT col FROM dbo.real_inner WHERE col > s.id) sub;
+END;
+GO
+`
+
+func TestTSQLApplyDerivedTableNoCallEdge(t *testing.T) {
+	// criterion 6: derived-table apply → no APPLY calls edge; inner FROM → references
+	ext := newSQL()
+	result, err := ext.Extract("/db/tsql_apply_derived.sql", tsqlApplyDerivedTableFixture)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	refs := result.UnresolvedReferences
+
+	// The derived-table alias 'sub' must never appear as a calls target.
+	if hasUnresolvedRef(refs, "sub", types.EdgeKindCalls) {
+		t.Error("derived-table alias 'sub' must not produce a calls edge from APPLY")
+	}
+	// Nothing should get a calls edge from this APPLY at all (no TVF invocation).
+	for _, r := range refs {
+		if r.ReferenceKind == types.EdgeKindCalls {
+			t.Errorf("no calls edge expected from a derived-table APPLY, got calls to %q", r.ReferenceName)
+		}
+	}
+	// The left source dbo.src → references edge (schema stripped to bare name).
+	if !hasUnresolvedRef(refs, "src", types.EdgeKindReferences) {
+		t.Error("expected references edge to 'src' from the left-hand FROM source")
+	}
+	// The inner FROM dbo.real_inner → references edge (schema stripped).
+	if !hasUnresolvedRef(refs, "real_inner", types.EdgeKindReferences) {
+		t.Error("expected references edge to 'real_inner' from inner FROM inside derived-table APPLY")
+	}
+}

--- a/docs/spec/tsql-lineage-gaps.md
+++ b/docs/spec/tsql-lineage-gaps.md
@@ -1,0 +1,128 @@
+# T-SQL APPLY lineage
+
+Extend the standalone SQL extractor (`atomic/internal/codeintel/extraction/standalone/sql.go`) so that
+`CROSS APPLY` and `OUTER APPLY` table-valued-function invocations in a routine/view body produce a
+`calls` edge to the invoked function. This closes the highest-value T-SQL lineage gap identified in the
+2026-06-09 coverage audit (issue #70): APPLY-driven table-valued-function lineage was previously invisible.
+
+Parent spec: `docs/spec/sql-language-support.md` (the extractor, its taxonomy, and the body-edge engine
+`scanBodyEdges`). This spec amends only the body-edge behavior; nothing else in the parent changes.
+
+## Why
+
+`scanBodyEdges` captures `FROM`/`JOIN` (references), `INSERT`/`UPDATE`/`DELETE`/`MERGE` (writes), and
+`EXEC`/`CALL` (calls). It deliberately does **not** run general function-call-in-expression scanning over
+routine bodies — that was found too noisy (see F-7 in the parent: fn-call capture is scoped to specific
+clauses). As a result, a table-valued function invoked through `CROSS APPLY dbo.GetLines(o.id)` produced
+no edge at all. APPLY is the canonical T-SQL idiom for correlated table-valued-function joins, so its
+absence left a class of proc→function lineage uncaptured.
+
+APPLY is the cheapest, lowest-false-positive win of the audit's gap list: the invoked target is always a
+parenthesized invocation, so it can be matched precisely without the noise that blanket expression
+scanning would introduce.
+
+## Approach
+
+One regex, one dispatch block in `scanBodyEdges`, mirroring the existing `bodyExecCallRE` → `calls` path.
+
+- New package-level regex:
+
+      var bodyApplyRE = regexp.MustCompile(`(?i)\b(?:CROSS|OUTER)\s+APPLY\s+(` + sqlQNameRaw + `)\s*\(`)
+
+  The trailing `\s*\(` is required: it restricts matches to **table-valued-function invocations**
+  (`APPLY name(...)`), which is the lineage-relevant case. A correlated-derived-table apply
+  (`CROSS APPLY (SELECT ... FROM real_table) x`) does not match — its capture group would have to start
+  with `(`, which `sqlQNameRaw` cannot — and that is correct: the inner `FROM real_table` is already
+  captured by the existing `FROM`/`JOIN` scan, so no lineage is lost.
+
+- New dispatch block in `scanBodyEdges`, placed after the `EXEC`/`CALL` block, following the identical
+  shape used by every other body-edge kind:
+
+      // CROSS APPLY / OUTER APPLY <tvf>( → calls
+      for _, m := range bodyApplyRE.FindAllStringSubmatchIndex(body, -1) {
+          rawName := body[m[2]:m[3]]
+          _, name := parseQName(rawName)
+          if name != "" {
+              addRef(name, types.EdgeKindCalls, m[2])
+          }
+      }
+
+  Reuses `parseQName` (so `dbo.GetLines` resolves to `GetLines`) and `addRef` (so keyword filtering, CTE
+  shadowing, and per-name+kind deduplication all apply unchanged).
+
+`EdgeKindCalls` is the correct kind: a parenthesized invocation is a call, consistent with how
+`EXEC`/`CALL` targets are emitted. Built-in TVFs (`STRING_SPLIT`, `OPENJSON`, …) will not resolve to a
+node and the unresolved reference is dropped by the resolver — the same graceful-degradation behavior the
+extractor already relies on for unknown targets.
+
+## Contract / success criteria
+
+1. `CROSS APPLY dbo.GetLines(o.id)` in a routine or view body emits a `calls` edge to `GetLines`.
+2. `OUTER APPLY GetTags(t.id)` emits a `calls` edge to `GetTags` (both APPLY flavors covered).
+3. A schema-qualified target (`CROSS APPLY analytics.fn_rollup(x)`) emits a `calls` edge to the bare
+   function name `fn_rollup` (schema stripped by `parseQName`, matching every other body edge).
+4. The table on the left of the APPLY keeps its existing edge: in
+   `FROM Orders o CROSS APPLY dbo.GetLines(o.id) l`, `Orders` still emits a `references` edge.
+5. No spurious edge to the keywords `CROSS`, `OUTER`, or `APPLY`.
+6. A correlated derived-table apply (`CROSS APPLY (SELECT ... FROM src) x`) emits **no** APPLY-derived
+   call edge; the inner `FROM src` still emits its `references` edge.
+7. Existing behavior is unchanged: the full standalone extractor test suite stays green (`OUTER JOIN`,
+   LATERAL, CTE shadow, EXEC/CALL, MERGE, etc. are unaffected — APPLY requires the literal `APPLY`
+   keyword).
+
+## Non-goals (explicitly out of scope — do not implement here)
+
+These remaining gaps from issue #70 are **not** addressed by this change and must not be added to it. They
+are not regex additions; they require a name-scoping decision the current name-based global resolver does
+not support, and pulling them in would broaden the change past its reviewed contract:
+
+- **Temp tables (`#tmp`, `##global`) and table variables (`@t`).** The resolver matches references to
+  nodes by global name; two different procedures' `#tmp` are distinct objects but would collide under
+  name-based resolution. Making intra-proc lineage correct needs proc-local scoping, not a regex — a
+  separate design.
+- **`OUTPUT ... INTO <target>`** write edges. Tractable for real-table targets but carries an
+  INTO-disambiguation false-positive risk (OUTPUT without INTO scanning forward to an unrelated INTO);
+  deferred to keep this change false-positive-free.
+- **`PIVOT` / `UNPIVOT`.**
+- **Column-level lineage.** Object-level only, per the parent spec; the audit flags this as an
+  industry-wide weak spot, out of scope.
+
+Issue #70 and the `tsql-lineage-gaps` follow-up remain open to track these.
+
+## Checkpoints
+
+A single checkpoint — one regex plus one dispatch block in `scanBodyEdges`, with tests.
+
+| # | Checkpoint | Files/areas | Verifies |
+|---|------------|-------------|----------|
+| 1 | CROSS/OUTER APPLY → `calls` edge | `atomic/internal/codeintel/extraction/standalone/sql.go` (+ `sql_test.go`) | `bodyApplyRE` dispatch emits a `calls` edge to the invoked TVF; schema stripped (`dbo.GetLines` → `GetLines`); left-of-APPLY table keeps its `references` edge; derived-table apply excluded; `CROSS`/`OUTER`/`APPLY` never become edges; full standalone suite stays green |
+
+## Test plan
+
+Add T-SQL-style fixtures and tests to `sql_test.go`, following the existing `const <name>Fixture` +
+`Test<Name>` + WHY-comment convention and using the `hasUnresolvedRef` / `countUnresolvedRefs` helpers:
+
+- `CROSS APPLY` TVF → `calls` edge (criterion 1).
+- `OUTER APPLY` TVF → `calls` edge (criterion 2).
+- Schema-qualified APPLY target → `calls` edge to bare name (criterion 3).
+- Combined fixture: `FROM Orders o CROSS APPLY dbo.GetLines(o.id) l` asserts both the `Orders`
+  `references` edge and the `GetLines` `calls` edge (criterion 4).
+- Negative: `CROSS`/`OUTER`/`APPLY` never appear as reference or call targets (criterion 5).
+- Negative: derived-table apply emits no APPLY call edge, but its inner `FROM` table does emit a
+  `references` edge (criterion 6).
+
+## Implementation log
+
+- 2026-06-23 — Implemented on branch `tsql-apply-lineage` (autopilot, issue #70). One regex
+  (`bodyApplyRE`) + one dispatch block in `scanBodyEdges` (`sql.go`); 6 tests in `sql_test.go`
+  (`TestTSQLCrossApplyCalls`, `TestTSQLOuterApplyCalls`, `TestTSQLApplySchemaStripped`,
+  `TestTSQLApplyKeywordsNotEdges`, `TestTSQLApplyDerivedTableNoCallEdge`). Reviewer: PASS (1 🔵 nit on the
+  derived-table fixture, fixed in-iteration). Standalone package suite green; module-wide `go vet`,
+  `gofmt`, `go build ./...`, and `atomic validate` clean.
+
+## Change log
+
+- 2026-06-24 — Added the `## Checkpoints` table required by `atomic validate` rule S5 (the spec predated S5
+  enforcement). No content change — the single checkpoint restates the existing Approach/Contract.
+- 2026-06-23 — Created. Scopes issue #70 to its highest-value win (CROSS/OUTER APPLY → `calls`); the other
+  audit gaps are listed as explicit non-goals with rationale.


### PR DESCRIPTION
## Summary

- Adds a `bodyApplyRE` dispatch to `scanBodyEdges` so `CROSS APPLY` / `OUTER APPLY` table-valued-function invocations emit a `calls` edge, mirroring the existing `EXEC`/`CALL` path.
- Scopes matches to TVF invocations via a trailing `(`; correlated derived-table applies don't match and lose nothing (their inner `FROM` is already captured).
- New focused spec `docs/spec/tsql-lineage-gaps.md` and six T-SQL tests in `sql_test.go`.

## What this solves

Closes the highest-value gap from the 2026-06-09 T-SQL coverage audit (#70). Routine bodies deliberately skip general function-call-in-expression scanning (too noisy), so a TVF invoked through `CROSS APPLY dbo.GetLines(o.id)` — the canonical T-SQL correlated-TVF idiom — previously produced no edge at all.

Temp tables, table variables, `OUTPUT ... INTO`, `PIVOT`/`UNPIVOT`, and column-level lineage remain explicit non-goals: they need a name-scoping decision the global name-based resolver doesn't support, not a regex addition. Issue #70 and the `tsql-lineage-gaps` follow-up stay open to track them.