### PR TITLE
feat(serve): live-reload open tabs on filesystem change

### DIFF
--- a/atomic/internal/serve/assets/app.css
+++ b/atomic/internal/serve/assets/app.css
@@ -406,6 +406,44 @@ a { color: inherit; text-decoration: none; }
 [data-theme="dark"] .theme-toggle .i-sun  { display: block; }
 [data-theme="dark"] .theme-toggle .i-moon { display: none; }
 
+/* Live-reload connectivity indicator (dot + label reflecting the /events
+   EventSource's live / reconnecting / disconnected state). Colors reuse the
+   existing repo (green) and knowledge (red) type-identity hues rather than
+   introducing new tokens. */
+.conn-indicator {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-family: var(--mono);
+    color: var(--ink-faint);
+    flex-shrink: 0;
+    letter-spacing: 0.02em;
+}
+
+.conn-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--ink-ghost);
+    flex-shrink: 0;
+    transition: background-color .2s;
+}
+
+.conn-indicator[data-conn-state="live"] .conn-dot { background: var(--c-repo-ink); }
+
+.conn-indicator[data-conn-state="reconnecting"] .conn-dot {
+    background: var(--amber);
+    animation: conn-dot-pulse 1.2s ease-in-out infinite;
+}
+
+.conn-indicator[data-conn-state="disconnected"] .conn-dot { background: var(--c-knowledge-ink); }
+
+@keyframes conn-dot-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: .35; }
+}
+
 /* Network/graph toggle button — active state (system graph visible) */
 #btn-graph.btn-graph-active {
     border-color: var(--amber-edge);

--- a/atomic/internal/serve/context_handler.go
+++ b/atomic/internal/serve/context_handler.go
@@ -227,8 +227,10 @@ type notFoundFragmentData struct {
 // Without shell, missing pages produce bare http.NotFound; found pages fall
 // back to the fragment template (unit tests that don't need the shell use this).
 //
-// g may be nil; nil degrades to NewPageHandler with no rail wiring.
-func NewPageHandlerWithGraph(root string, g *Graph, shell ...*ShellRenderer) http.Handler {
+// g may be nil; nil degrades to NewPageHandler with no rail wiring. g is
+// typically the shared *snapshotStore (CP2 live-reload) so the graph read
+// below reflects the realm as of this request, not the state at construction.
+func NewPageHandlerWithGraph(root string, g graphProvider, shell ...*ShellRenderer) http.Handler {
 	var sh *ShellRenderer
 	if len(shell) > 0 {
 		sh = shell[0]
@@ -243,6 +245,10 @@ func NewPageHandlerWithGraph(root string, g *Graph, shell ...*ShellRenderer) htt
 			http.NotFound(w, r)
 			return
 		}
+
+		// Resolved once per request so the render below reflects one
+		// consistent graph even if a live rebuild lands mid-request.
+		graph := g.currentGraph()
 
 		isHX := fragmentRequest(r)
 
@@ -275,7 +281,7 @@ func NewPageHandlerWithGraph(root string, g *Graph, shell ...*ShellRenderer) htt
 					serve404(w, r, relPath, "/page/"+relPath, isHX, sh)
 					return
 				}
-				bodyHTML, hasMermaid, err = RenderMarkdownWithGraph(data, root, idxRel, g)
+				bodyHTML, hasMermaid, err = RenderMarkdownWithGraph(data, root, idxRel, graph)
 				if err != nil {
 					http.Error(w, "render error", http.StatusInternalServerError)
 					return
@@ -291,7 +297,7 @@ func NewPageHandlerWithGraph(root string, g *Graph, shell ...*ShellRenderer) htt
 				serve404(w, r, relPath, "/page/"+relPath, isHX, sh)
 				return
 			}
-			bodyHTML, hasMermaid, err = RenderMarkdownWithGraph(data, root, normRelPath(relPath), g)
+			bodyHTML, hasMermaid, err = RenderMarkdownWithGraph(data, root, normRelPath(relPath), graph)
 			if err != nil {
 				http.Error(w, "render error", http.StatusInternalServerError)
 				return

--- a/atomic/internal/serve/context_handler.go
+++ b/atomic/internal/serve/context_handler.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 )
@@ -211,6 +212,22 @@ type notFoundFragmentData struct {
 	Path string
 }
 
+// isNilGraphProvider reports whether g represents "no graph": a bare nil
+// interface, or a typed-nil pointer (nil *Graph, nil *snapshotStore, ...)
+// boxed into the graphProvider interface. A boxed typed-nil pointer carries a
+// non-nil type descriptor, so a plain `g == nil` comparison is always false
+// for it — the interface only equals nil when both its type and value are
+// unset — even though the underlying pointer has nothing to read. Every
+// graphProvider implementation in this package is a pointer type, so the
+// Kind check makes the IsNil call safe.
+func isNilGraphProvider(g graphProvider) bool {
+	if g == nil {
+		return true
+	}
+	v := reflect.ValueOf(g)
+	return v.Kind() == reflect.Ptr && v.IsNil()
+}
+
 // NewPageHandlerWithGraph returns an http.Handler for /page/* that renders
 // markdown and wires the right rail. htmx fragment requests emit one OOB loader
 // into #rail-graph-content; the loader fires GET /rail/<relpath> which returns
@@ -227,15 +244,17 @@ type notFoundFragmentData struct {
 // Without shell, missing pages produce bare http.NotFound; found pages fall
 // back to the fragment template (unit tests that don't need the shell use this).
 //
-// g may be nil; nil degrades to NewPageHandler with no rail wiring. g is
-// typically the shared *snapshotStore (CP2 live-reload) so the graph read
-// below reflects the realm as of this request, not the state at construction.
+// g may be nil — including a typed-nil *Graph or *snapshotStore boxed into
+// the interface (see isNilGraphProvider) — and degrades to NewPageHandler
+// with no rail wiring. g is typically the shared *snapshotStore (CP2
+// live-reload) so the graph read below reflects the realm as of this
+// request, not the state at construction.
 func NewPageHandlerWithGraph(root string, g graphProvider, shell ...*ShellRenderer) http.Handler {
 	var sh *ShellRenderer
 	if len(shell) > 0 {
 		sh = shell[0]
 	}
-	if g == nil {
+	if isNilGraphProvider(g) {
 		return NewPageHandler(root)
 	}
 

--- a/atomic/internal/serve/context_handler.go
+++ b/atomic/internal/serve/context_handler.go
@@ -213,19 +213,26 @@ type notFoundFragmentData struct {
 }
 
 // isNilGraphProvider reports whether g represents "no graph": a bare nil
-// interface, or a typed-nil pointer (nil *Graph, nil *snapshotStore, ...)
-// boxed into the graphProvider interface. A boxed typed-nil pointer carries a
-// non-nil type descriptor, so a plain `g == nil` comparison is always false
-// for it — the interface only equals nil when both its type and value are
-// unset — even though the underlying pointer has nothing to read. Every
-// graphProvider implementation in this package is a pointer type, so the
-// Kind check makes the IsNil call safe.
+// interface, or a typed-nil value (nil *Graph, nil *snapshotStore, or any
+// other nilable-kind implementor) boxed into the graphProvider interface. A
+// boxed typed-nil value carries a non-nil type descriptor, so a plain
+// `g == nil` comparison is always false for it — the interface only equals
+// nil when both its type and value are unset — even though the underlying
+// value has nothing to read. The Kind switch covers every nilable reflect
+// kind (Ptr, Map, Slice, Chan, Func, Interface) so any typed-nil provider
+// degrades, not just pointer implementors; IsNil panics on a non-nilable
+// kind, which is why the switch guards it.
 func isNilGraphProvider(g graphProvider) bool {
 	if g == nil {
 		return true
 	}
 	v := reflect.ValueOf(g)
-	return v.Kind() == reflect.Ptr && v.IsNil()
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 // NewPageHandlerWithGraph returns an http.Handler for /page/* that renders

--- a/atomic/internal/serve/context_handler_internal_test.go
+++ b/atomic/internal/serve/context_handler_internal_test.go
@@ -1,0 +1,62 @@
+package serve
+
+// Tests for the typed-nil graphProvider trap in NewPageHandlerWithGraph
+// (FOLLOWUPS F-3): a nil *snapshotStore or nil *Graph passed as the
+// graphProvider argument boxes into a non-nil interface value (the interface
+// carries a type descriptor even though the pointer it holds is nil), so a
+// naive `g == nil` check does not see it. The constructor's own doc comment
+// promises "g may be nil ... degrades to NewPageHandler" — this test proves
+// that promise actually holds for every concrete graphProvider implementor,
+// not just a bare untyped nil.
+//
+// Why internal: snapshotStore is unexported, so constructing a typed-nil
+// *snapshotStore requires package serve rather than serve_test.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewPageHandlerWithGraph_TypedNilGraphProviderDegradesWithoutPanic verifies
+// that a typed-nil *snapshotStore or *Graph takes the exact same no-graph
+// degrade path as NewPageHandlerWithGraph(root, nil) — not a panic when the
+// handler later reads through the nil concrete pointer.
+func TestNewPageHandlerWithGraph_TypedNilGraphProviderDegradesWithoutPanic(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "page.md"), []byte("# Page\n"), 0o644); err != nil {
+		t.Fatalf("write page.md: %v", err)
+	}
+
+	// Baseline: what the documented no-graph degrade produces.
+	want := NewPageHandler(root)
+	reqWant := httptest.NewRequest(http.MethodGet, "/page/page.md", nil)
+	reqWant.Header.Set("HX-Request", "true")
+	rrWant := httptest.NewRecorder()
+	want.ServeHTTP(rrWant, reqWant)
+
+	cases := map[string]graphProvider{
+		"nil *snapshotStore": (*snapshotStore)(nil),
+		"nil *Graph":         (*Graph)(nil),
+	}
+
+	for name, g := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := NewPageHandlerWithGraph(root, g)
+
+			req := httptest.NewRequest(http.MethodGet, "/page/page.md", nil)
+			req.Header.Set("HX-Request", "true")
+			rr := httptest.NewRecorder()
+			got.ServeHTTP(rr, req) // must not panic
+
+			if rr.Code != rrWant.Code {
+				t.Errorf("status: got %d, want %d (degrade path must match NewPageHandler)", rr.Code, rrWant.Code)
+			}
+			if rr.Body.String() != rrWant.Body.String() {
+				t.Errorf("body must match the plain NewPageHandler degrade path:\ngot:  %s\nwant: %s", rr.Body.String(), rrWant.Body.String())
+			}
+		})
+	}
+}

--- a/atomic/internal/serve/context_handler_internal_test.go
+++ b/atomic/internal/serve/context_handler_internal_test.go
@@ -20,6 +20,24 @@ import (
 	"testing"
 )
 
+// nilMapGraphProvider is a defined map type implementing graphProvider (FOLLOWUPS
+// F-5): isNilGraphProvider must catch a typed-nil non-pointer implementor, not
+// just nil pointers.
+type nilMapGraphProvider map[string]int
+
+func (nilMapGraphProvider) currentGraph() *Graph { return nil }
+
+// TestIsNilGraphProvider_NonPointerTypedNil proves isNilGraphProvider degrades
+// for a typed-nil implementor whose underlying kind is not reflect.Ptr — the
+// same trap the pointer cases below guard against, just on a map instead.
+func TestIsNilGraphProvider_NonPointerTypedNil(t *testing.T) {
+	var m nilMapGraphProvider // nil map value
+	var g graphProvider = m
+	if !isNilGraphProvider(g) {
+		t.Error("isNilGraphProvider(nil map-typed provider) = false, want true")
+	}
+}
+
 // TestNewPageHandlerWithGraph_TypedNilGraphProviderDegradesWithoutPanic verifies
 // that a typed-nil *snapshotStore or *Graph takes the exact same no-graph
 // degrade path as NewPageHandlerWithGraph(root, nil) — not a panic when the

--- a/atomic/internal/serve/events.go
+++ b/atomic/internal/serve/events.go
@@ -1,0 +1,221 @@
+// events.go — CP3 (live-reload): the /events SSE endpoint and the
+// subscriber-gated server ticker.
+//
+// Today, a change on disk is only reflected the next time a handler happens
+// to be requested — the snapshot store (snapshot.go) validates lazily, but
+// nothing pushes that fact to an open browser tab. This file adds the push
+// side: /events streams {fp, changed} over a plain EventSource, fed by a
+// single ticker goroutine started once at server startup and stopped by the
+// server context.
+//
+// The ticker is subscriber-gated: with zero open /events connections it does
+// not even perform the cheap stat-only fingerprint walk (SC12), so an idle
+// `atomic serve` with no browser tab open costs nothing beyond the ticker's
+// own timer wakeups.
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// changedCap bounds the manifest diff carried in a changeEvent. Above the
+	// cap the field is omitted entirely rather than truncated, and clients
+	// treat an omitted field as "everything may have changed" (SC16) — past
+	// this size the enumeration itself stops being useful.
+	changedCap = 100
+
+	// sseWriteDeadline bounds each write to a subscriber's connection so a
+	// stalled TCP peer cannot hang that subscriber's goroutine forever. It is
+	// independent of shutdown responsiveness — that is the request context's
+	// job (serve.go wires the server's BaseContext to the same context that
+	// drives srv.Shutdown) — this deadline is purely about a dead peer that
+	// never disconnects.
+	sseWriteDeadline = 5 * time.Second
+)
+
+// changeEvent is the /events wire payload: the realm fingerprint and the
+// manifest diff since the subscriber's last-seen state. Changed is nil (not
+// present in the JSON, via omitempty) once it exceeds changedCap — the client
+// treats a missing Changed the same as an oversized one: refetch everything.
+type changeEvent struct {
+	FP      string   `json:"fp"`
+	Changed []string `json:"changed,omitempty"`
+}
+
+// newChangeEvent builds the wire payload for a fingerprint and its manifest
+// diff, applying changedCap.
+func newChangeEvent(fp string, changed []string) changeEvent {
+	if len(changed) > changedCap {
+		return changeEvent{FP: fp}
+	}
+	return changeEvent{FP: fp, Changed: changed}
+}
+
+// subscriber is one connected /events client's coalescing slot: a buffered-1
+// channel that push overwrites rather than blocks on when the subscriber
+// hasn't drained the previous event.
+type subscriber struct {
+	ch chan changeEvent
+}
+
+// push delivers ev to the subscriber's slot without ever blocking: a full
+// slot (the subscriber hasn't read its previous event yet) is drained and
+// replaced, so the subscriber always sees the latest state once it catches
+// up, and this call — and therefore broadcast's caller, the ticker — never
+// stalls on a slow or dead subscriber (SC14).
+func (s *subscriber) push(ev changeEvent) {
+	select {
+	case s.ch <- ev:
+		return
+	default:
+	}
+	select {
+	case <-s.ch:
+	default:
+	}
+	select {
+	case s.ch <- ev:
+	default:
+	}
+}
+
+// subscriberRegistry tracks every connected /events client. The ticker reads
+// count() to decide whether to do any work at all (SC12); NewEventsHandler
+// registers and unregisters through subscribe's returned unsubscribe func.
+type subscriberRegistry struct {
+	mu   sync.Mutex
+	subs map[*subscriber]struct{}
+}
+
+// newSubscriberRegistry constructs an empty registry.
+func newSubscriberRegistry() *subscriberRegistry {
+	return &subscriberRegistry{subs: make(map[*subscriber]struct{})}
+}
+
+// subscribe registers a new subscriber and returns its slot plus an
+// unsubscribe func the caller must invoke exactly once when the connection
+// ends.
+func (r *subscriberRegistry) subscribe() (*subscriber, func()) {
+	s := &subscriber{ch: make(chan changeEvent, 1)}
+	r.mu.Lock()
+	r.subs[s] = struct{}{}
+	r.mu.Unlock()
+	return s, func() {
+		r.mu.Lock()
+		delete(r.subs, s)
+		r.mu.Unlock()
+	}
+}
+
+// broadcast pushes ev to every subscriber's slot, coalescing to the latest.
+func (r *subscriberRegistry) broadcast(ev changeEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for s := range r.subs {
+		s.push(ev)
+	}
+}
+
+// count returns the current subscriber count — the ticker's gate (SC12).
+func (r *subscriberRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.subs)
+}
+
+// NewEventsHandler returns the GET /events SSE handler (Subscribe flow):
+// register a subscriber, immediately push a resync event reflecting current
+// on-disk state regardless of the tick cycle, then stream subsequent
+// broadcast events from the subscriber's slot until the request context ends
+// (client disconnect or server shutdown).
+func NewEventsHandler(store *snapshotStore, registry *subscriberRegistry) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		sub, unsubscribe := registry.subscribe()
+		defer unsubscribe()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no") // defeat any intermediary buffering
+		w.WriteHeader(http.StatusOK)
+
+		snap, changed := store.ensureFresh()
+		if !writeChangeEvent(w, flusher, newChangeEvent(snap.fp, changed)) {
+			return
+		}
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev := <-sub.ch:
+				if !writeChangeEvent(w, flusher, ev) {
+					return
+				}
+			}
+		}
+	})
+}
+
+// writeChangeEvent JSON-encodes ev as one SSE message event (the client's
+// plain EventSource.onmessage — no custom event name), applying a bounded
+// write deadline so a stalled peer cannot hang this goroutine indefinitely.
+// Returns false when the caller should stop streaming.
+func writeChangeEvent(w http.ResponseWriter, flusher http.Flusher, ev changeEvent) bool {
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return false
+	}
+	// Best-effort: not every ResponseWriter supports a write deadline (e.g. a
+	// unit test's httptest.ResponseRecorder); proceed without one rather than
+	// fail the write over it.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+		return false
+	}
+	flusher.Flush()
+	return true
+}
+
+// startTicker starts the single ticker goroutine for the server's lifetime
+// (SC11): gated on subscriber count so a zero-subscriber tick performs no
+// walk at all (SC12), it otherwise calls store.ensureFresh() and — only when
+// that call actually rebuilt (changed != nil; a nil result means either the
+// fingerprint was unchanged or a rebuild was already in flight) — broadcasts
+// {fp, changed} to every subscriber. The goroutine exits when ctx is
+// cancelled; callers must pass the same context that drives the server's
+// graceful shutdown so the ticker never outlives it.
+func startTicker(ctx context.Context, store *snapshotStore, registry *subscriberRegistry, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if registry.count() == 0 {
+					continue
+				}
+				snap, changed := store.ensureFresh()
+				if changed == nil {
+					continue
+				}
+				registry.broadcast(newChangeEvent(snap.fp, changed))
+			}
+		}
+	}()
+}

--- a/atomic/internal/serve/events_internal_test.go
+++ b/atomic/internal/serve/events_internal_test.go
@@ -1,0 +1,307 @@
+package serve
+
+// events_internal_test.go — CP3 (live-reload): subscriberRegistry, changeEvent,
+// NewEventsHandler, and startTicker.
+//
+// Why internal: subscriberRegistry, changeEvent, and startTicker are
+// unexported (NewEventsHandler is the only exported seam), so these tests
+// live in package serve rather than serve_test. writeSnapFile and the
+// defaultTickInterval/defaultQuietWindow constants come from
+// snapshot_internal_test.go / snapshot.go in this same package.
+//
+// Per the checkpoint's grounding note, the streaming tests use
+// httptest.NewServer with a real client reading a bounded-context request —
+// not the search_stream_test.go ResponseRecorder pattern, which only works
+// for bounded (non-open-ended) streams.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readOneEvent reads one SSE "data: <json>" frame from br, skipping the
+// blank lines the wire format uses as event separators, and decodes it.
+func readOneEvent(br *bufio.Reader) (changeEvent, error) {
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return changeEvent{}, err
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+		var ev changeEvent
+		if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+			return changeEvent{}, err
+		}
+		return ev, nil
+	}
+}
+
+// TestNewChangeEvent_OmitsChangedOverCap verifies SC16: the changed field is
+// present up to changedCap entries and omitted entirely (not truncated) once
+// the diff exceeds it.
+func TestNewChangeEvent_OmitsChangedOverCap(t *testing.T) {
+	atCap := make([]string, changedCap)
+	for i := range atCap {
+		atCap[i] = fmt.Sprintf("f%d.md", i)
+	}
+
+	ev := newChangeEvent("fp1", atCap)
+	if ev.Changed == nil {
+		t.Fatal("at-cap changed list must still be present")
+	}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(payload), `"changed"`) {
+		t.Errorf("expected changed field present at cap, got %s", payload)
+	}
+
+	overCap := append(atCap, "one-more.md")
+	ev2 := newChangeEvent("fp1", overCap)
+	if ev2.Changed != nil {
+		t.Errorf("over-cap changed list must be omitted, got %v", ev2.Changed)
+	}
+	payload2, err := json.Marshal(ev2)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(payload2), `"changed"`) {
+		t.Errorf("expected changed field omitted over cap, got %s", payload2)
+	}
+}
+
+// TestSubscriberRegistry_CountTracksSubscribeUnsubscribe verifies count() —
+// the ticker's zero-subscriber gate (SC12) — reflects subscribe/unsubscribe
+// edges precisely.
+func TestSubscriberRegistry_CountTracksSubscribeUnsubscribe(t *testing.T) {
+	registry := newSubscriberRegistry()
+	if got := registry.count(); got != 0 {
+		t.Fatalf("count = %d, want 0 before any subscribe", got)
+	}
+
+	_, unsubA := registry.subscribe()
+	_, unsubB := registry.subscribe()
+	if got := registry.count(); got != 2 {
+		t.Fatalf("count = %d, want 2", got)
+	}
+
+	unsubA()
+	if got := registry.count(); got != 1 {
+		t.Fatalf("count = %d, want 1 after one unsubscribe", got)
+	}
+
+	unsubB()
+	if got := registry.count(); got != 0 {
+		t.Fatalf("count = %d, want 0 after both unsubscribed", got)
+	}
+}
+
+// TestSubscriberRegistry_BroadcastCoalescesForSlowSubscriber verifies SC14: a
+// subscriber that never drains its slot never blocks broadcast, and its slot
+// ends up holding only the latest event rather than queueing every one.
+func TestSubscriberRegistry_BroadcastCoalescesForSlowSubscriber(t *testing.T) {
+	registry := newSubscriberRegistry()
+
+	subA, unsubA := registry.subscribe()
+	defer unsubA()
+	subB, unsubB := registry.subscribe()
+	defer unsubB()
+
+	ev1 := changeEvent{FP: "fp1"}
+	ev2 := changeEvent{FP: "fp2"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		registry.broadcast(ev1)
+		registry.broadcast(ev2)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("broadcast blocked on an undrained subscriber slot")
+	}
+
+	select {
+	case got := <-subA.ch:
+		if got.FP != ev2.FP {
+			t.Errorf("subA: got fp %q, want coalesced latest %q", got.FP, ev2.FP)
+		}
+	default:
+		t.Error("subA slot must hold the coalesced latest event")
+	}
+	select {
+	case got := <-subB.ch:
+		if got.FP != ev2.FP {
+			t.Errorf("subB: got fp %q, want coalesced latest %q", got.FP, ev2.FP)
+		}
+	default:
+		t.Error("subB slot must hold the coalesced latest event")
+	}
+}
+
+// TestNewEventsHandler_ResyncPushOnSubscribe verifies SC13: a new
+// subscription receives an immediate fp check-and-push, not a wait for the
+// next tick (no ticker is even started in this test).
+func TestNewEventsHandler_ResyncPushOnSubscribe(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "a.md", "# A\n")
+
+	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+	registry := newSubscriberRegistry()
+
+	srv := httptest.NewServer(NewEventsHandler(store, registry))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ev, err := readOneEvent(bufio.NewReader(resp.Body))
+	if err != nil {
+		t.Fatalf("read resync event: %v", err)
+	}
+	if want := store.current().fp; ev.FP != want {
+		t.Errorf("resync fp = %q, want current snapshot fp %q", ev.FP, want)
+	}
+}
+
+// TestStartTicker_ZeroSubscribers_NoRebuild verifies SC12: with zero
+// subscribers, the ticker performs no work at all — not even the cheap
+// fingerprint walk that would notice a pending on-disk change — proven by
+// planting a change and confirming no rebuild ever happens before a
+// subscriber attaches, and one does happen shortly after.
+func TestStartTicker_ZeroSubscribers_NoRebuild(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "a.md", "# A\n")
+
+	interval := 20 * time.Millisecond
+	store := newSnapshotStore(root, interval, defaultQuietWindow)
+	store.ensureFresh() // warm, matching NewSnapshotStore's synchronous warm
+
+	registry := newSubscriberRegistry()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startTicker(ctx, store, registry, interval)
+
+	// Plant a change while zero subscribers are attached.
+	writeSnapFile(t, root, "b.md", "# B\n")
+
+	baseline := store.rebuildCalls.Load()
+	time.Sleep(10 * interval)
+	if got := store.rebuildCalls.Load(); got != baseline {
+		t.Errorf("ticker rebuilt with 0 subscribers: rebuildCalls %d -> %d", baseline, got)
+	}
+
+	// Attaching a subscriber must let the very next tick pick up the pending
+	// change — proving the gate, not some other stall, explains the above.
+	_, unsubscribe := registry.subscribe()
+	defer unsubscribe()
+
+	time.Sleep(10 * interval)
+	if got := store.rebuildCalls.Load(); got == baseline {
+		t.Error("ticker never rebuilt once a subscriber was attached")
+	}
+}
+
+// TestStartTicker_NoRebuildWhenFingerprintUnchanged verifies the tick flow's
+// no-op path: with a subscriber attached but nothing changed on disk, the
+// ticker's repeated ensureFresh calls never trigger a rebuild.
+func TestStartTicker_NoRebuildWhenFingerprintUnchanged(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "a.md", "# A\n")
+
+	interval := 20 * time.Millisecond
+	store := newSnapshotStore(root, interval, defaultQuietWindow)
+	store.ensureFresh() // warm
+
+	registry := newSubscriberRegistry()
+	_, unsubscribe := registry.subscribe()
+	defer unsubscribe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startTicker(ctx, store, registry, interval)
+
+	baseline := store.rebuildCalls.Load()
+	time.Sleep(10 * interval)
+	if got := store.rebuildCalls.Load(); got != baseline {
+		t.Errorf("ticker rebuilt an unchanged realm: rebuildCalls %d -> %d", baseline, got)
+	}
+}
+
+// TestStartTicker_BroadcastsChangeToSubscriberAfterTick verifies the full
+// Tick flow end to end: a subscribed client, after an on-disk change, sees a
+// tick-triggered event (distinct from its initial resync push) carrying the
+// changed relpath.
+func TestStartTicker_BroadcastsChangeToSubscriberAfterTick(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "a.md", "# A\n")
+
+	interval := 20 * time.Millisecond
+	store := newSnapshotStore(root, interval, defaultQuietWindow)
+	store.ensureFresh() // warm, matching NewSnapshotStore's synchronous warm
+
+	registry := newSubscriberRegistry()
+	srv := httptest.NewServer(NewEventsHandler(store, registry))
+	defer srv.Close()
+
+	tickerCtx, cancelTicker := context.WithCancel(context.Background())
+	defer cancelTicker()
+	startTicker(tickerCtx, store, registry, interval)
+
+	reqCtx, cancelReq := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelReq()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	br := bufio.NewReader(resp.Body)
+	if _, err := readOneEvent(br); err != nil {
+		t.Fatalf("read resync event: %v", err)
+	}
+
+	writeSnapFile(t, root, "b.md", "# B\n")
+
+	ev, err := readOneEvent(br)
+	if err != nil {
+		t.Fatalf("read tick-triggered event: %v", err)
+	}
+	found := false
+	for _, c := range ev.Changed {
+		if c == "b.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected b.md in tick-triggered changed set, got %v", ev.Changed)
+	}
+}

--- a/atomic/internal/serve/events_test.go
+++ b/atomic/internal/serve/events_test.go
@@ -1,0 +1,143 @@
+package serve_test
+
+// events_test.go — CP3 (live-reload): /events route wiring and shutdown,
+// exercised through the real production server (startTestServer /
+// serve.RunWithContext) rather than a bare handler, since these behaviors
+// depend on serve.go's route registration and the ctx-driven shutdown wiring
+// (BaseContext + the ticker's own lifecycle), not on NewEventsHandler alone.
+//
+// Per the checkpoint's grounding note, these use a real streaming client
+// reading a bounded-context request against a real listener — not the
+// search_stream_test.go ResponseRecorder pattern, which only works for
+// bounded (non-open-ended) streams.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEvents_RouteReachable_NoCollisionWithStatus verifies SC10: /events is a
+// distinct, reachable route that streams an immediate resync push (SC13),
+// and /status still resolves to the health dashboard rather than the SSE
+// stream.
+func TestEvents_RouteReachable_NoCollisionWithStatus(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "README.md"), "# Readme\n")
+
+	baseURL, shutdown := startTestServer(t, startOpts(t, dir))
+	defer shutdown()
+	waitReady(t, baseURL+"/healthz", 3*time.Second)
+
+	statusResp, err := http.Get(baseURL + "/status")
+	if err != nil {
+		t.Fatalf("GET /status: %v", err)
+	}
+	defer statusResp.Body.Close()
+	if ct := statusResp.Header.Get("Content-Type"); strings.Contains(ct, "text/event-stream") {
+		t.Errorf("/status unexpectedly served as an SSE stream: %s", ct)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/events", nil)
+	if err != nil {
+		t.Fatalf("build /events request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("/events Content-Type = %q, want text/event-stream", ct)
+	}
+
+	line, err := readDataLine(bufio.NewReader(resp.Body))
+	if err != nil {
+		t.Fatalf("read first SSE line: %v", err)
+	}
+	var payload struct {
+		FP      string   `json:"fp"`
+		Changed []string `json:"changed"`
+	}
+	if err := json.Unmarshal([]byte(line), &payload); err != nil {
+		t.Fatalf("unmarshal resync payload %q: %v", line, err)
+	}
+	if payload.FP == "" {
+		t.Error("resync payload fp must not be empty")
+	}
+}
+
+// TestEvents_ShutdownWithLiveSubscriber_CompletesPromptly verifies SC15: the
+// /events handler returns promptly on server shutdown — Ctrl-C with an open
+// tab exits within the existing 5s graceful window — even with a subscriber
+// actively connected and reading.
+func TestEvents_ShutdownWithLiveSubscriber_CompletesPromptly(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "README.md"), "# Readme\n")
+
+	baseURL, shutdown := startTestServer(t, startOpts(t, dir))
+	waitReady(t, baseURL+"/healthz", 3*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/events", nil)
+	if err != nil {
+		t.Fatalf("build /events request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Keep actively reading so the connection stays live (not idle) across
+	// shutdown, mirroring a real open browser tab.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		buf := make([]byte, 512)
+		for {
+			if _, err := resp.Body.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	start := time.Now()
+	shutdown() // cancels the server context; asserts (via startTestServer) it exits within 5s
+	elapsed := time.Since(start)
+
+	if elapsed >= 4*time.Second {
+		t.Errorf("shutdown with a live /events subscriber took %v, want comfortably under the 5s window", elapsed)
+	}
+
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Error("subscriber's /events connection was never closed after shutdown")
+	}
+}
+
+// readDataLine reads lines from br until it finds a non-blank "data: ..."
+// frame and returns its JSON payload, trimmed.
+func readDataLine(br *bufio.Reader) (string, error) {
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		return strings.TrimSpace(strings.TrimPrefix(trimmed, "data:")), nil
+	}
+}

--- a/atomic/internal/serve/fe8_test.go
+++ b/atomic/internal/serve/fe8_test.go
@@ -326,24 +326,26 @@ func TestBreadcrumbTopLevelPageHasNoAncestorLinks(t *testing.T) {
 // ─── 6. GraphDataHandler uses injected graph ──────────────────────────────────
 
 // TestGraphDataHandlerUsesInjectedGraph verifies that NewGraphDataHandlerWithGraph
-// uses the provided graph instead of rebuilding BuildLinkGraph per request.
+// uses the graph resolved through the given store instead of rebuilding
+// BuildLinkGraph(root) per request.
 //
 // WHY: rebuilding the link graph on every /graph/data request causes per-request
-// latency proportional to realm size. The graph is built once at startup in serve.go
-// and should be shared with GraphDataHandler.
+// latency proportional to realm size. The graph is resolved from the shared
+// snapshot store (CP2), not from GraphDataHandler's own root, on every request.
 func TestGraphDataHandlerUsesInjectedGraph(t *testing.T) {
 	// Use an empty temp dir as root. If GraphDataHandler rebuilt the graph from root,
-	// it would return 0 nodes (no .md files). We inject an empty graph explicitly
-	// and confirm the response reflects it — proving the injected graph is used.
+	// it would return 0 nodes (no .md files). We inject a store rooted at a
+	// different, empty directory and confirm the response reflects that store's
+	// (empty) graph — proving the injected store is used, not root.
 	root := t.TempDir()
 	// Write a markdown file so that a per-request BuildLinkGraph would produce nodes.
 	writeFile(t, filepath.Join(root, "page.md"), "# Page\n")
 
-	// Build an empty graph (not from root) to inject.
-	emptyRoot := t.TempDir() // empty dir → 0 nodes
-	injectedGraph := serve.BuildLinkGraph(emptyRoot)
+	// Store rooted at a different, empty dir (not root) → 0 nodes.
+	emptyRoot := t.TempDir()
+	store := serve.NewSnapshotStore(emptyRoot)
 
-	handler := serve.NewGraphDataHandlerWithGraph(root, injectedGraph)
+	handler := serve.NewGraphDataHandlerWithGraph(root, store)
 
 	req := httptest.NewRequest(http.MethodGet, "/graph/data", nil)
 	rr := httptest.NewRecorder()

--- a/atomic/internal/serve/graphcache.go
+++ b/atomic/internal/serve/graphcache.go
@@ -2,38 +2,36 @@
 //
 // The full /graph/data response (no ?node= param) is assembled from
 // BuildProvenanceDAG + buildCytoElements + injectProvenanceEdges + JSON marshal.
-// The link graph is already built once at startup, but the provenance walk
-// (reads + sha256s every wiki page) and the whole-realm element assembly used to
-// run on EVERY Network View open — a noticeable wait each time.
+// The provenance walk (reads + sha256s every wiki page) and the whole-realm
+// element assembly used to run on EVERY Network View open — a noticeable wait
+// each time.
 //
 // graphDataCache assembles it once, warmed in a background goroutine at startup,
-// and serves the bytes verbatim until the realm changes. Change detection is a
-// sha256 fingerprint over a manifest of every non-hidden file's (relpath, size,
-// mtime) under the root — cheap (stat-only, no content reads) and sensitive to
-// edits. Concurrent (re)builds are deduped via singleflight, so a burst of
-// requests — or the warm goroutine racing the first request — triggers exactly
-// one assembly.
+// and serves the bytes verbatim until the realm changes. Change detection and the
+// link graph itself both come from a snapshotStore (CP1): the store's ensureFresh
+// does the stat-only fingerprint walk (and, when stale, the heavier graph rebuild)
+// so this cache no longer walks the filesystem on its own — it only owns the
+// provenance+cyto-JSON assembly and its cache. Concurrent (re)builds of that
+// assembly are still deduped via singleflight keyed by the store's fingerprint, so
+// a burst of requests — or the warm goroutine racing the first request — triggers
+// exactly one assembly.
 package serve
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"io/fs"
 	"path/filepath"
-	"strconv"
 	"sync"
 
 	"golang.org/x/sync/singleflight"
 )
 
-// graphDataCache caches the full-view /graph/data JSON keyed by a filesystem
-// fingerprint. Safe for concurrent use.
+// graphDataCache caches the full-view /graph/data JSON keyed by the
+// snapshotStore's filesystem fingerprint. Safe for concurrent use.
 type graphDataCache struct {
 	root    string
 	wikiDir string
-	graph   *Graph // prebuilt link graph (static for the server's lifetime)
+	store   *snapshotStore // source of the link graph + fingerprint (CP1)
 
 	sf singleflight.Group // dedupes concurrent assembles by fingerprint
 
@@ -42,58 +40,20 @@ type graphDataCache struct {
 	cachedJSON []byte // cached full-view elements JSON (nil until first build)
 }
 
-// newGraphDataCache builds a cache over the prebuilt link graph g rooted at root.
-func newGraphDataCache(root string, g *Graph) *graphDataCache {
+// newGraphDataCache builds a cache over store, rooted at root.
+func newGraphDataCache(root string, store *snapshotStore) *graphDataCache {
 	return &graphDataCache{
 		root:    root,
 		wikiDir: filepath.Join(root, "wiki"),
-		graph:   g,
+		store:   store,
 	}
-}
-
-// fingerprint hashes a manifest of (relpath|size|mtimeNano) for every non-hidden
-// file under root, using the same dir/file filters as BuildLinkGraph so it tracks
-// exactly the files the graph + provenance overlay depend on. Stat-only — no file
-// contents are read, so it is cheap to recompute per request.
-func (c *graphDataCache) fingerprint() string {
-	h := sha256.New()
-	_ = filepath.WalkDir(c.root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if path != c.root && shouldSkipDir(d.Name()) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if hiddenFile(d.Name()) {
-			return nil
-		}
-		rel, relErr := filepath.Rel(c.root, path)
-		if relErr != nil {
-			return nil
-		}
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			return nil
-		}
-		h.Write([]byte(filepath.ToSlash(rel)))
-		h.Write([]byte{0})
-		h.Write([]byte(strconv.FormatInt(info.Size(), 10)))
-		h.Write([]byte{0})
-		h.Write([]byte(strconv.FormatInt(info.ModTime().UnixNano(), 10)))
-		h.Write([]byte{'\n'})
-		return nil
-	})
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // assemble builds the full-view elements JSON exactly as GraphDataHandler does for
 // a no-node-param request (SetEscapeHTML(false) so labels keep raw <, >, &).
-func (c *graphDataCache) assemble() ([]byte, error) {
+func (c *graphDataCache) assemble(g *Graph) ([]byte, error) {
 	provDAG := BuildProvenanceDAG(c.root, c.wikiDir)
-	elems := buildCytoElements(c.graph)
+	elems := buildCytoElements(g)
 	injectProvenanceEdges(&elems, provDAG)
 
 	var buf bytes.Buffer
@@ -111,8 +71,14 @@ func (c *graphDataCache) assemble() ([]byte, error) {
 // share one assemble via singleflight. The fingerprint is surfaced to the client
 // (X-Graph-Fingerprint header) so the browser can key its layout cache off the
 // exact realm state — it changes on any edit, not just node-set changes.
+//
+// ensureFresh does the store's own lightweight (or, when stale, full) walk on
+// every call — the same lazy-validation cost this cache always paid, now
+// shared with nav paths instead of duplicated here.
 func (c *graphDataCache) fullJSON() (data []byte, fingerprint string, err error) {
-	fp := c.fingerprint()
+	snap, _ := c.store.ensureFresh()
+	fp := snap.fp
+	g := snap.graph
 
 	c.mu.RLock()
 	if c.fp == fp && c.cachedJSON != nil {
@@ -132,7 +98,7 @@ func (c *graphDataCache) fullJSON() (data []byte, fingerprint string, err error)
 		}
 		c.mu.RUnlock()
 
-		b, aErr := c.assemble()
+		b, aErr := c.assemble(g)
 		if aErr != nil {
 			return nil, aErr
 		}

--- a/atomic/internal/serve/graphoverlay.go
+++ b/atomic/internal/serve/graphoverlay.go
@@ -245,11 +245,13 @@ func buildLocalSubgraph(g *Graph, nodeID string, depth int) cytoElements {
 // It accepts an optional ?node=<relpath>&depth=<1|2> for local views.
 type GraphDataHandler struct {
 	root string
-	// graph is an optional pre-built link graph. When non-nil it is used directly
-	// instead of rebuilding on every request (FE8: cache the graph at startup).
-	// When nil, BuildLinkGraph is called per-request (original behaviour, kept for
-	// NewGraphDataHandler callers that do not have a pre-built graph).
-	graph *Graph
+	// store is the shared snapshot store (CP2 live-reload). When non-nil,
+	// both the full-view cache and the node-specific local-view branch below
+	// read the current graph through it, so a file added, edited, or removed
+	// after startup is reflected on the next request without a restart. nil
+	// for the per-request NewGraphDataHandler constructor, which falls back
+	// to a fresh BuildLinkGraph call per request (original behaviour).
+	store *snapshotStore
 	// cache caches the full-view (no ?node=) assembly — provenance walk + element
 	// build + marshal — keyed by a filesystem fingerprint, warmed in the background
 	// at startup. nil for the per-request NewGraphDataHandler constructor.
@@ -258,29 +260,23 @@ type GraphDataHandler struct {
 
 // NewGraphDataHandler returns an http.Handler for /graph/data that builds the
 // link graph on every request. Prefer NewGraphDataHandlerWithGraph when a
-// startup-built graph is available to avoid per-request latency.
+// shared snapshot store is available to avoid per-request latency.
 func NewGraphDataHandler(root string) http.Handler {
 	return &GraphDataHandler{root: root}
 }
 
-// NewGraphDataHandlerWithGraph returns an http.Handler for /graph/data that
-// uses the supplied pre-built graph instead of rebuilding it on every request.
-// g must not be nil. This is the preferred constructor when the caller already
-// builds a link graph at startup (as serve.go does via BuildLinkGraph).
-//
-// CP1 (live-reload): the full-view cache is backed by a snapshotStore seeded
-// with g, so a request no longer serves a startup-frozen graph forever — once
-// the realm changes on disk, the store's lazy fingerprint check rebuilds it.
-// The node-specific local-view branch below still reads the static g field
-// (handler migration to the store is checkpoint 2).
-func NewGraphDataHandlerWithGraph(root string, g *Graph) http.Handler {
-	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
-	store.seed(g)
+// NewGraphDataHandlerWithGraph returns an http.Handler for /graph/data backed
+// by store: both the full-view cache and the node-specific local-view branch
+// read the current graph through store.currentGraph, so a request no longer
+// serves a startup-frozen graph — once the realm changes on disk, the store's
+// lazy fingerprint check (shared with the nav/page/rail handlers — SC7)
+// rebuilds it. store must not be nil.
+func NewGraphDataHandlerWithGraph(root string, store *snapshotStore) http.Handler {
 	cache := newGraphDataCache(root, store)
 	// Warm the full-view assembly in the background so the first Network View open
 	// serves cached bytes instead of waiting on the provenance walk.
 	go cache.warm()
-	return &GraphDataHandler{root: root, graph: g, cache: cache}
+	return &GraphDataHandler{root: root, store: store, cache: cache}
 }
 
 func (h *GraphDataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -303,9 +299,12 @@ func (h *GraphDataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// On assemble error, fall through to the live path below.
 	}
 
-	// Use the injected graph when available; fall back to per-request build.
-	g := h.graph
-	if g == nil {
+	// Use the shared store when available (resolves once per request, live);
+	// fall back to a fresh per-request build (NewGraphDataHandler callers).
+	var g *Graph
+	if h.store != nil {
+		g = h.store.currentGraph()
+	} else {
 		g = BuildLinkGraph(h.root)
 	}
 

--- a/atomic/internal/serve/graphoverlay.go
+++ b/atomic/internal/serve/graphoverlay.go
@@ -267,8 +267,16 @@ func NewGraphDataHandler(root string) http.Handler {
 // uses the supplied pre-built graph instead of rebuilding it on every request.
 // g must not be nil. This is the preferred constructor when the caller already
 // builds a link graph at startup (as serve.go does via BuildLinkGraph).
+//
+// CP1 (live-reload): the full-view cache is backed by a snapshotStore seeded
+// with g, so a request no longer serves a startup-frozen graph forever — once
+// the realm changes on disk, the store's lazy fingerprint check rebuilds it.
+// The node-specific local-view branch below still reads the static g field
+// (handler migration to the store is checkpoint 2).
 func NewGraphDataHandlerWithGraph(root string, g *Graph) http.Handler {
-	cache := newGraphDataCache(root, g)
+	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+	store.seed(g)
+	cache := newGraphDataCache(root, store)
 	// Warm the full-view assembly in the background so the first Network View open
 	// serves cached bytes instead of waiting on the provenance walk.
 	go cache.warm()

--- a/atomic/internal/serve/livereload_handler_test.go
+++ b/atomic/internal/serve/livereload_handler_test.go
@@ -1,0 +1,225 @@
+package serve_test
+
+// livereload_handler_test.go — CP2 (live-reload): handler migration tests.
+//
+// CP1 built the shared snapshotStore; CP2 wires nav, page, rail, and
+// graph-data to read through it (retiring the startup-frozen BuildLinkGraph
+// singleton and the per-request nav walk). These tests exercise that wiring
+// through real HTTP round-trips against the full production server
+// (startTestServer / RunWithContext), proving a file added after the server
+// starts is reflected on the very next request — no restart required.
+//
+// A newly-written fixture file's mtime is "now", which falls inside the
+// snapshotStore's default 2s quiet window (see snapshot.go) and would not
+// yet flip the fingerprint. Each test backdates the new file's mtime past
+// that window (mirroring snapshot_internal_test.go's writeSnapFile helper)
+// so the very next request already observes it, rather than sleeping in the
+// test.
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// backdateFile sets path's mtime an hour in the past so a freshly-written
+// fixture file clears the snapshot store's quiet window immediately.
+func backdateFile(t *testing.T, path string) {
+	t.Helper()
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+// TestGraphDataFullView_ReflectsFileAddedAfterStartup verifies F-1: a file
+// added to the realm after the server has started appears in the full-view
+// /graph/data response on a later request, proving GraphDataHandler no
+// longer serves a startup-frozen graph — through real HTTP round-trips
+// against the public handler (not a store-internal unit test).
+func TestGraphDataFullView_ReflectsFileAddedAfterStartup(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "alpha.md"), "# Alpha\n")
+
+	baseURL, shutdown := startTestServer(t, startOpts(t, root))
+	defer shutdown()
+	waitReady(t, baseURL+"/healthz", 3*time.Second)
+
+	resp, err := http.Get(baseURL + "/graph/data")
+	if err != nil {
+		t.Fatalf("GET /graph/data (baseline): %v", err)
+	}
+	baseline, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read baseline body: %v", err)
+	}
+	if strings.Contains(string(baseline), `"beta.md"`) {
+		t.Fatalf("baseline /graph/data unexpectedly already contains beta.md: %s", baseline)
+	}
+
+	betaPath := filepath.Join(root, "beta.md")
+	writeFile(t, betaPath, "# Beta\n")
+	backdateFile(t, betaPath)
+
+	resp2, err := http.Get(baseURL + "/graph/data")
+	if err != nil {
+		t.Fatalf("GET /graph/data (after add): %v", err)
+	}
+	defer resp2.Body.Close()
+	after, err := io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatalf("read after body: %v", err)
+	}
+
+	if !strings.Contains(string(after), `"beta.md"`) {
+		t.Errorf("expected beta.md in /graph/data after being added post-startup (no restart); got:\n%s", after)
+	}
+}
+
+// TestNav_ReflectsFileAddedAfterStartup verifies that a repo-scope nav tree
+// reflects a docs file created after the server has started, without a
+// restart — proving the per-request docs-tree walk is now sourced from the
+// shared snapshot instead of a frozen or independently-walked file list.
+func TestNav_ReflectsFileAddedAfterStartup(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "README.md"), "# Readme\n")
+
+	baseURL, shutdown := startTestServer(t, startOpts(t, root))
+	defer shutdown()
+	waitReady(t, baseURL+"/healthz", 3*time.Second)
+
+	resp, err := http.Get(baseURL + "/nav")
+	if err != nil {
+		t.Fatalf("GET /nav (baseline): %v", err)
+	}
+	baseline, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read baseline nav body: %v", err)
+	}
+	if strings.Contains(string(baseline), "docs/guide.md") {
+		t.Fatalf("baseline nav unexpectedly already contains docs/guide.md: %s", baseline)
+	}
+
+	guidePath := filepath.Join(root, "docs", "guide.md")
+	writeFile(t, guidePath, "# Guide\n")
+	backdateFile(t, guidePath)
+
+	resp2, err := http.Get(baseURL + "/nav")
+	if err != nil {
+		t.Fatalf("GET /nav (after add): %v", err)
+	}
+	defer resp2.Body.Close()
+	after, err := io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatalf("read after nav body: %v", err)
+	}
+
+	if !strings.Contains(string(after), "docs/guide.md") {
+		t.Errorf("expected docs/guide.md in nav after being added post-startup (no restart); got:\n%s", after)
+	}
+}
+
+// TestRail_ReflectsBacklinkFromFileAddedAfterStartup verifies that the right
+// rail's inbound-links (#rail-in-content) fragment reflects a backlink from a
+// page created after the server started, without a restart.
+func TestRail_ReflectsBacklinkFromFileAddedAfterStartup(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "hub.md"), "# Hub\n\nNo links yet.\n")
+
+	baseURL, shutdown := startTestServer(t, startOpts(t, root))
+	defer shutdown()
+	waitReady(t, baseURL+"/healthz", 3*time.Second)
+
+	resp, err := http.Get(baseURL + "/rail/hub.md")
+	if err != nil {
+		t.Fatalf("GET /rail/hub.md (baseline): %v", err)
+	}
+	baseline, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read baseline rail body: %v", err)
+	}
+	if strings.Contains(string(baseline), "spoke.md") {
+		t.Fatalf("baseline rail unexpectedly already contains spoke.md: %s", baseline)
+	}
+
+	spokePath := filepath.Join(root, "spoke.md")
+	writeFile(t, spokePath, "# Spoke\n\nSee [[hub]].\n")
+	backdateFile(t, spokePath)
+
+	resp2, err := http.Get(baseURL + "/rail/hub.md")
+	if err != nil {
+		t.Fatalf("GET /rail/hub.md (after add): %v", err)
+	}
+	defer resp2.Body.Close()
+	after, err := io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatalf("read after rail body: %v", err)
+	}
+
+	if !strings.Contains(string(after), "spoke.md") {
+		t.Errorf("expected spoke.md backlink in #rail-in-content after being added post-startup (no restart); got:\n%s", after)
+	}
+}
+
+// TestPage_WikilinkToFileAddedAfterStartup_Resolves verifies that a wikilink
+// pointing at a page created after the server started resolves (renders as a
+// real link, not the wikilink-broken class) on the next /page request.
+func TestPage_WikilinkToFileAddedAfterStartup_Resolves(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "hub.md"), "# Hub\n\nSee [[leaf]].\n")
+
+	baseURL, shutdown := startTestServer(t, startOpts(t, root))
+	defer shutdown()
+	waitReady(t, baseURL+"/healthz", 3*time.Second)
+
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/page/hub.md", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("HX-Request", "true")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /page/hub.md (baseline): %v", err)
+	}
+	baseline, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read baseline page body: %v", err)
+	}
+	if !strings.Contains(string(baseline), "wikilink-broken") {
+		t.Fatalf("baseline [[leaf]] must render broken (leaf.md does not exist yet); got:\n%s", baseline)
+	}
+
+	leafPath := filepath.Join(root, "leaf.md")
+	writeFile(t, leafPath, "# Leaf\n")
+	backdateFile(t, leafPath)
+
+	req2, err := http.NewRequest(http.MethodGet, baseURL+"/page/hub.md", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req2.Header.Set("HX-Request", "true")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("GET /page/hub.md (after add): %v", err)
+	}
+	defer resp2.Body.Close()
+	after, err := io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatalf("read after page body: %v", err)
+	}
+
+	if strings.Contains(string(after), "wikilink-broken") {
+		t.Errorf("expected [[leaf]] to resolve once leaf.md exists (no restart); got:\n%s", after)
+	}
+	if !strings.Contains(string(after), `/page/leaf.md`) {
+		t.Errorf("expected resolved wikilink to link to /page/leaf.md; got:\n%s", after)
+	}
+}

--- a/atomic/internal/serve/nav.go
+++ b/atomic/internal/serve/nav.go
@@ -73,15 +73,44 @@ type NavOptions struct {
 	// production default (computeStaleness) is used.  Tests may inject a
 	// stub to avoid disk/git I/O.
 	StalenessFn StalenessFn
+
+	// Store is the shared snapshot store (CP2 live-reload) backing the
+	// repo-scope nav tree's file list, shared with the page/rail/graph-data
+	// handlers so a single walk serves all of them. Realm-scope nav does not
+	// read Store — members/concerns/knowledge/buckets are read from the wiki
+	// index and their own directories directly (unchanged).
+	//
+	// nil is a valid fallback for callers (tests) that construct NavOptions
+	// directly without a shared store: NewNavHandler builds a private
+	// one-off store rooted at RealmRoot, so repo-scope nav still works, just
+	// without sharing its walk with any other handler.
+	Store *snapshotStore
+}
+
+// sseLiveParam is the query parameter CP4's client-side EventSource-triggered
+// nav refetch sets on GET /nav (e.g. "/nav?live=1") so the handler can skip
+// computeStaleness — a git-subprocess-backed check — on every live-reload
+// refresh. An ordinary navigation request (no param) still runs it.
+const sseLiveParam = "live"
+
+// isSSETriggered reports whether r carries the SSE-triggered nav marker.
+func isSSETriggered(r *http.Request) bool {
+	return r.URL.Query().Get(sseLiveParam) != ""
 }
 
 // NewNavHandler returns an http.Handler for the /nav route.
 func NewNavHandler(opts NavOptions) http.Handler {
+	store := opts.Store
+	if store == nil && !opts.IsRealmScope {
+		store = newSnapshotStore(opts.RealmRoot, defaultTickInterval, defaultQuietWindow)
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-		// Resolve staleness once per request.
-		if opts.IsRealmScope {
+		// Resolve staleness once per request — skipped for an SSE-triggered
+		// refresh so a live-reload tick never pays the git-subprocess cost.
+		if opts.IsRealmScope && !isSSETriggered(r) {
 			fn := opts.StalenessFn
 			if fn == nil {
 				fn = computeStaleness
@@ -95,7 +124,8 @@ func NewNavHandler(opts NavOptions) http.Handler {
 		if opts.IsRealmScope {
 			renderRealmNav(&sb, opts)
 		} else {
-			renderRepoNav(&sb, opts.RealmRoot)
+			snap, _ := store.ensureFresh()
+			renderRepoNav(&sb, snap.navPaths)
 		}
 
 		fmt.Fprint(w, sb.String())
@@ -196,20 +226,37 @@ func memberLinkRel(realmRoot string, m wiki.Member) string {
 // ─── repo nav ────────────────────────────────────────────────────────────────
 
 // renderRepoNav writes a docs file tree nav for a bare repo (no wiki).
-func renderRepoNav(sb *strings.Builder, root string) {
+//
+// navPaths is the snapshot's root-relative .md file list (CP2 live-reload):
+// the same single walk that produces the fingerprint and link graph, instead
+// of this function performing its own independent filesystem walk. A file
+// added, edited, or removed since the last snapshot rebuild is reflected here
+// because the caller (NewNavHandler) re-derives navPaths via ensureFresh on
+// every request.
+func renderRepoNav(sb *strings.Builder, navPaths []string) {
 	// ── README.md (top-level markdown files) ──────────────────────────────
 	sb.WriteString("<details open>\n")
 	sb.WriteString("<summary class=\"nav-group\">Docs</summary>\n")
 
-	// Top-level .md files (README.md and siblings).
-	topMDs := walkMarkdownFiles(root)
+	// Top-level .md files (README.md and siblings) — navPaths entries with no
+	// "/" are direct children of root; navPaths is already sorted, so the
+	// filtered subsets stay sorted without a second sort.
+	var topMDs []string
+	var docsFiles []string // relative to "docs/", i.e. with the prefix stripped
+	for _, p := range navPaths {
+		if !strings.Contains(p, "/") {
+			topMDs = append(topMDs, p)
+			continue
+		}
+		if rest, ok := strings.CutPrefix(p, "docs/"); ok {
+			docsFiles = append(docsFiles, rest)
+		}
+	}
 	for _, name := range topMDs {
 		writeNavLeaf(sb, stripMDExt(name), name)
 	}
 
 	// docs/**/*.md — render as nested <details> folder tree.
-	docsDir := filepath.Join(root, "docs")
-	docsFiles := walkMarkdownFilesRecursive(docsDir)
 	writeNavFolderTree(sb, "docs", docsFiles)
 
 	sb.WriteString("</details>\n")

--- a/atomic/internal/serve/nav_test.go
+++ b/atomic/internal/serve/nav_test.go
@@ -527,3 +527,40 @@ func TestNavTreeBucketFolderIsBrowsable(t *testing.T) {
 		t.Errorf("bucket should no longer render a dead nav-leaf span, got:\n%s", body)
 	}
 }
+
+// TestNavTreeSSETriggeredRequestSkipsStaleness verifies CP2: a nav request
+// carrying the SSE-triggered marker (?live=1) does not invoke the staleness
+// seam at all, while an ordinary navigation request (no marker) still does.
+//
+// WHY: computeStaleness is git-subprocess-backed; a live-reload refresh that
+// fires on every on-disk change must not pay that cost on every tick.
+func TestNavTreeSSETriggeredRequestSkipsStaleness(t *testing.T) {
+	root := buildMinimalWikiRealm(t)
+
+	var calls int
+	handler := serve.NewNavHandler(serve.NavOptions{
+		RealmRoot:     root,
+		IsRealmScope:  true,
+		WikiIndexPath: filepath.Join(root, "wiki", "index.md"),
+		StalenessFn: func(_, _ string) (map[string]bool, map[string]bool) {
+			calls++
+			return map[string]bool{}, map[string]bool{}
+		},
+	})
+
+	// SSE-triggered request: the staleness seam must not be called.
+	req := httptest.NewRequest(http.MethodGet, "/nav?live=1", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if calls != 0 {
+		t.Errorf("SSE-triggered nav request must skip StalenessFn, got %d calls", calls)
+	}
+
+	// Ordinary navigation request: the staleness seam must still run.
+	req2 := httptest.NewRequest(http.MethodGet, "/nav", nil)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+	if calls != 1 {
+		t.Errorf("ordinary nav request must still call StalenessFn, got %d calls", calls)
+	}
+}

--- a/atomic/internal/serve/rail_handler.go
+++ b/atomic/internal/serve/rail_handler.go
@@ -126,9 +126,11 @@ type railTmplData struct {
 }
 
 // NewRailHandler returns an http.Handler for /rail/<relpath>.
-// It renders three OOB fragments for the right rail using the prebuilt Graph g.
-// Traversal outside root and pages absent from the graph yield 404.
-func NewRailHandler(root string, g *Graph) http.Handler {
+// It renders three OOB fragments for the right rail using the graph resolved
+// through g (a static *Graph for tests, or the shared *snapshotStore in
+// production — CP2 live-reload). Traversal outside root and pages absent from
+// the graph yield 404.
+func NewRailHandler(root string, g graphProvider) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relPath := strings.TrimPrefix(r.URL.Path, "/rail/")
 		if relPath == "" || relPath == "/" {
@@ -143,9 +145,13 @@ func NewRailHandler(root string, g *Graph) http.Handler {
 			return
 		}
 
+		// Resolved once per request so the fragment below reflects one
+		// consistent graph.
+		graph := g.currentGraph()
+
 		// Graph-membership check: page must be a known .md file (O(1) via nodeSet).
 		rel := normRelPath(relPath)
-		if !g.Has(rel) {
+		if !graph.Has(rel) {
 			http.NotFound(w, r)
 			return
 		}
@@ -184,9 +190,9 @@ func NewRailHandler(root string, g *Graph) http.Handler {
 			Page:        rel,
 			PageEncoded: rel, // forward-slash paths are safe in query params
 			CyID:        cyID,
-			Orphan:      g.IsOrphan(rel),
-			Backlinks:   g.Backlinks(rel),
-			Outbound:    g.Outbound(rel),
+			Orphan:      graph.IsOrphan(rel),
+			Backlinks:   graph.Backlinks(rel),
+			Outbound:    graph.Outbound(rel),
 			Properties:  props,
 		}
 

--- a/atomic/internal/serve/rail_handler.go
+++ b/atomic/internal/serve/rail_handler.go
@@ -130,7 +130,17 @@ type railTmplData struct {
 // through g (a static *Graph for tests, or the shared *snapshotStore in
 // production — CP2 live-reload). Traversal outside root and pages absent from
 // the graph yield 404.
+//
+// g may be nil — including a typed-nil *Graph or *snapshotStore boxed into
+// the interface (see isNilGraphProvider) — in which case every request
+// degrades to 404: with no graph there is nothing to confirm a page's
+// membership against, the same outcome the graph-membership check below
+// already produces for a page the graph doesn't know about.
 func NewRailHandler(root string, g graphProvider) http.Handler {
+	if isNilGraphProvider(g) {
+		return http.HandlerFunc(http.NotFound)
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relPath := strings.TrimPrefix(r.URL.Path, "/rail/")
 		if relPath == "" || relPath == "/" {

--- a/atomic/internal/serve/rail_handler_internal_test.go
+++ b/atomic/internal/serve/rail_handler_internal_test.go
@@ -1,0 +1,48 @@
+package serve
+
+// Tests for the typed-nil graphProvider trap in NewRailHandler (same footgun
+// as NewPageHandlerWithGraph, see context_handler_internal_test.go): a nil
+// *snapshotStore or nil *Graph passed as the graphProvider argument boxes
+// into a non-nil interface value, so a naive `g == nil` check does not catch
+// it and the handler panics dereferencing the nil concrete pointer.
+//
+// Why internal: snapshotStore is unexported, so constructing a typed-nil
+// *snapshotStore requires package serve rather than serve_test.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewRailHandler_TypedNilGraphProviderDegradesWithoutPanic verifies that a
+// typed-nil *snapshotStore or *Graph does not panic when NewRailHandler serves
+// a request — it must degrade to 404, matching the handler's existing
+// "page not in graph" branch (no graph means no page can be confirmed a member).
+func TestNewRailHandler_TypedNilGraphProviderDegradesWithoutPanic(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "page.md"), []byte("# Page\n"), 0o644); err != nil {
+		t.Fatalf("write page.md: %v", err)
+	}
+
+	cases := map[string]graphProvider{
+		"nil *snapshotStore": (*snapshotStore)(nil),
+		"nil *Graph":         (*Graph)(nil),
+	}
+
+	for name, g := range cases {
+		t.Run(name, func(t *testing.T) {
+			handler := NewRailHandler(root, g)
+
+			req := httptest.NewRequest(http.MethodGet, "/rail/page.md", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req) // must not panic
+
+			if rr.Code != http.StatusNotFound {
+				t.Errorf("status: got %d, want %d (degrade path must be 404 — no graph, no confirmed membership)", rr.Code, http.StatusNotFound)
+			}
+		})
+	}
+}

--- a/atomic/internal/serve/serve.go
+++ b/atomic/internal/serve/serve.go
@@ -156,6 +156,11 @@ func RunWithContext(ctx context.Context, opts Options) int {
 	// synchronous startup cost the old BuildLinkGraph(navRoot) call did here.
 	store := NewSnapshotStore(navRoot)
 
+	// eventsRegistry tracks connected /events (SSE) subscribers. The ticker
+	// started below reads its count to decide whether to do any work at all
+	// (SC12); NewEventsHandler registers/unregisters through it per connection.
+	eventsRegistry := newSubscriberRegistry()
+
 	navOpts := NavOptions{
 		RealmRoot:     navRoot,
 		IsRealmScope:  isRealmScope,
@@ -235,6 +240,11 @@ func RunWithContext(ctx context.Context, opts Options) int {
 		// Seams are nil → production defaults wired inside NewHealthHandler.
 	}
 	mux.Handle("/status", NewHealthHandler(healthOpts))
+
+	// /events — live-reload SSE stream (CP3): register, resync push, stream
+	// until the request context ends. Distinct route from /status — a health
+	// probe and the live-reload push channel are different concerns.
+	mux.Handle("/events", NewEventsHandler(store, eventsRegistry))
 
 	// /search — dedicated full-pane search page (streams results via SSE).
 	// Document loads are shell-wrapped; the search dialog links here for "view all".
@@ -363,7 +373,19 @@ func RunWithContext(ctx context.Context, opts Options) int {
 		mux.ServeHTTP(w, r)
 	})
 
-	srv := &http.Server{Handler: handler}
+	srv := &http.Server{
+		Handler: handler,
+		// BaseContext ties every request's context to the same ctx that
+		// drives graceful shutdown below. srv.Shutdown does not itself cancel
+		// in-flight request contexts — without this, an open /events
+		// connection's ctx.Done() would never fire, and Shutdown would block
+		// on it for the full 5s grace window instead of returning promptly.
+		BaseContext: func(net.Listener) context.Context { return ctx },
+	}
+
+	// The live-reload ticker (CP3) is bound to the same ctx: it must stop
+	// exactly when the server starts shutting down, never before or after.
+	startTicker(ctx, store, eventsRegistry, store.tickInterval)
 
 	// Serve in a background goroutine.
 	serveErr := make(chan error, 1)

--- a/atomic/internal/serve/serve.go
+++ b/atomic/internal/serve/serve.go
@@ -148,10 +148,19 @@ func RunWithContext(ctx context.Context, opts Options) int {
 		navRoot = realmRes.RealmRoot
 		wikiIndexPath = filepath.Join(realmRes.RealmRoot, "wiki", "index.md")
 	}
+	// store is the single shared realm-snapshot store (CP2 live-reload): nav,
+	// page, rail, and graph-data all read through it instead of each
+	// tracking its own copy, so the ticker (CP3), lazy per-request
+	// validation, and NewSnapshotStore's synchronous warm all observe — and
+	// refresh — the same realm state (SC7). The warm gives the same
+	// synchronous startup cost the old BuildLinkGraph(navRoot) call did here.
+	store := NewSnapshotStore(navRoot)
+
 	navOpts := NavOptions{
 		RealmRoot:     navRoot,
 		IsRealmScope:  isRealmScope,
 		WikiIndexPath: wikiIndexPath,
+		Store:         store,
 	}
 
 	// Parse and cache the embedded template.
@@ -200,18 +209,13 @@ func RunWithContext(ctx context.Context, opts Options) int {
 		TargetDir:  opts.TargetDir,
 	}
 
-	// Build the link graph once at server start. BuildLinkGraph is read-only and
-	// cheap at wiki-scale; rebuilding per-request (as /graph/data does) is also
-	// acceptable but a single build here keeps the rail handler stateless.
-	linkGraph := BuildLinkGraph(navRoot)
-
 	// /page/* — render a markdown file from the scope root, wired to the rail.
 	// FE8: non-htmx requests receive the shell with LandingURL = the requested path.
-	mux.Handle("/page/", NewPageHandlerWithGraph(opts.TargetDir, linkGraph, shell))
+	mux.Handle("/page/", NewPageHandlerWithGraph(opts.TargetDir, store, shell))
 
 	// /rail/* — right-rail compositing: three OOB fragments for the focused page
 	// (#rail-out-content, #rail-in-content, #rail-graph-content).
-	mux.Handle("/rail/", NewRailHandler(navRoot, linkGraph))
+	mux.Handle("/rail/", NewRailHandler(navRoot, store))
 
 	// /file/* — syntax-highlighted source view from the scope root.
 	// FE8: non-htmx requests receive the shell with LandingURL = the requested path.
@@ -255,8 +259,9 @@ func RunWithContext(ctx context.Context, opts Options) int {
 	}))
 
 	// /graph/data — Cytoscape elements JSON (CP9, SC11).
-	// FE8: pass the startup-built linkGraph so /graph/data does not rebuild per-request.
-	mux.Handle("/graph/data", NewGraphDataHandlerWithGraph(navRoot, linkGraph))
+	// Shares the store above so /graph/data does not rebuild per-request and
+	// stays live (CP2) instead of serving a startup-frozen graph.
+	mux.Handle("/graph/data", NewGraphDataHandlerWithGraph(navRoot, store))
 
 	// /graph — the Network View as its own page (URL-addressable, history-tracked,
 	// refresh-survivable). htmx requests get the #system-cy mount fragment; the

--- a/atomic/internal/serve/snapshot.go
+++ b/atomic/internal/serve/snapshot.go
@@ -102,6 +102,46 @@ func newSnapshotStore(root string, tickInterval, quietWindow time.Duration) *sna
 	return s
 }
 
+// NewSnapshotStore constructs the shared realm-snapshot store, at production
+// defaults, that backs the nav/page/rail/graph-data handlers (CP2).
+// RunWithContext constructs exactly one and injects it into every handler
+// constructor so a single walk — and a single rebuild funnel — is shared
+// across all of them, instead of each handler tracking its own copy (SC1,
+// SC7). Exported so tests exercising the handlers' post-startup live-reload
+// behavior through the public API can construct one the same way.
+//
+// The store is warmed synchronously before this returns (unlike the
+// unexported newSnapshotStore, which starts empty): a caller of an exported
+// constructor must never observe a nil graph, including a handler's
+// background cache-warm goroutine racing the caller's own first request.
+func NewSnapshotStore(root string) *snapshotStore {
+	s := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+	s.ensureFresh()
+	return s
+}
+
+// graphProvider is the seam the page, rail, and graph-data handlers read the
+// current link graph through. *Graph satisfies it as a static, single-shot
+// value (pre-CP2 callers, tests that build one graph and never expect it to
+// change); *snapshotStore satisfies it by calling ensureFresh on every read —
+// the same accessor the ticker and startup warm use (SC7) — so a file added,
+// edited, or deleted after construction is reflected on the next call without
+// the caller reconstructing the handler.
+type graphProvider interface {
+	currentGraph() *Graph
+}
+
+// currentGraph makes *Graph a graphProvider: a bare graph is one immutable
+// snapshot, so it simply returns itself.
+func (g *Graph) currentGraph() *Graph { return g }
+
+// currentGraph makes *snapshotStore a graphProvider: every call revalidates
+// the realm fingerprint (and rebuilds when stale) before returning the graph.
+func (s *snapshotStore) currentGraph() *Graph {
+	snap, _ := s.ensureFresh()
+	return snap.graph
+}
+
 // seed publishes an initial snapshot built from an already-constructed graph
 // (e.g. one built once at server startup) instead of performing a rebuild
 // walk. The snapshot's fingerprint reflects the current on-disk state, so a

--- a/atomic/internal/serve/snapshot.go
+++ b/atomic/internal/serve/snapshot.go
@@ -1,0 +1,253 @@
+// snapshot.go — CP1 (live-reload): the realm snapshot store.
+//
+// Today, three independent walks compute overlapping state: nav.go walks the
+// docs tree on every /nav request, serve.go builds the link graph once at
+// startup and never again, and graphcache.go walks the filesystem for a
+// fingerprint on every /graph/data request. Because they run independently, a
+// file added after startup shows up in some views and not others, and none of
+// them notice a change without a full server restart.
+//
+// snapshotStore replaces all three with one realm-wide snapshot — fingerprint,
+// nav paths, and link graph — behind a single atomic pointer, refreshed by one
+// rebuild funnel that any caller (a ticker, a lazy per-request check, the
+// startup warm) can trigger through the same accessor: ensureFresh.
+//
+// Two walk tiers exist:
+//   - fingerprint(): a cheap, stat-only, quiet-window-filtered manifest walk.
+//     Run on every ensureFresh call to detect drift without touching file
+//     content.
+//   - rebuild(): the expensive walk (BuildLinkGraph reads and parses every
+//     page), run only when fingerprint() reports the realm has changed.
+//
+// Concurrent callers that all observe staleness do not each perform a
+// rebuild. Only one wins a non-blocking CAS gate; the rest return the current
+// (possibly one-tick-stale) snapshot immediately rather than waiting — the
+// dedup key is that gate, not the computed fingerprint value, because two
+// walkers racing a changing filesystem can legitimately compute different
+// fingerprints for the same moment.
+package serve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// defaultTickInterval is the ticker cadence a store uses when a caller
+	// does not need a different cadence (production default; CP3 wires the
+	// live ticker at this interval).
+	defaultTickInterval = 10 * time.Second
+
+	// defaultQuietWindow is how recently a file may have been modified before
+	// its size/mtime resets are trusted enough to enter the fingerprint
+	// manifest — a file mid-write should not flip the fingerprint out from
+	// under a reader.
+	defaultQuietWindow = 2 * time.Second
+)
+
+// fileManifestEntry is one file's (size, mtime) pair as observed by a
+// fingerprint walk. Comparable, so two entries can be diffed with !=.
+type fileManifestEntry struct {
+	size        int64
+	modUnixNano int64
+}
+
+// realmSnapshot is one immutable view of realm state: the filesystem
+// fingerprint, the navigable markdown paths, and the resolved link graph.
+// Published as a single atomic pointer swap so a reader that grabs the
+// pointer once observes internally consistent state — a torn read (new fp,
+// stale graph) is impossible because there is only ever one field to read.
+type realmSnapshot struct {
+	fp       string
+	navPaths []string
+	graph    *Graph
+	manifest map[string]fileManifestEntry
+}
+
+// snapshotStore owns the current realmSnapshot behind a single atomic
+// pointer, the quiet-window fingerprint walk, and the rebuild funnel that
+// collapses concurrent triggers into one rebuild.
+type snapshotStore struct {
+	root         string
+	tickInterval time.Duration
+	quietWindow  time.Duration
+
+	ptr atomic.Pointer[realmSnapshot]
+
+	// rebuilding gates the funnel: only the goroutine that wins this
+	// CompareAndSwap performs a rebuild. Losers return the current
+	// (possibly stale) snapshot immediately — a later ensureFresh call
+	// (next tick, next request) retries. This is the generation-keyed
+	// dedup: the gate, not the fingerprint value, decides "already in
+	// flight" (SC7).
+	rebuilding atomic.Bool
+
+	// rebuildCalls counts completed rebuild() calls. Test instrumentation
+	// only — proves concurrent ensureFresh callers collapse to one rebuild.
+	rebuildCalls atomic.Int64
+}
+
+// newSnapshotStore constructs a store rooted at root with the given tick
+// interval and quiet window. The store starts with an empty snapshot; the
+// first ensureFresh call performs the initial rebuild.
+func newSnapshotStore(root string, tickInterval, quietWindow time.Duration) *snapshotStore {
+	s := &snapshotStore{root: root, tickInterval: tickInterval, quietWindow: quietWindow}
+	s.ptr.Store(&realmSnapshot{})
+	return s
+}
+
+// seed publishes an initial snapshot built from an already-constructed graph
+// (e.g. one built once at server startup) instead of performing a rebuild
+// walk. The snapshot's fingerprint reflects the current on-disk state, so a
+// later ensureFresh call correctly detects whether anything has changed since
+// g was built. Callers that already hold a graph use this to hand ongoing
+// revalidation over to the store without discarding what they built.
+func (s *snapshotStore) seed(g *Graph) {
+	entries, fp := s.fingerprint()
+	s.ptr.Store(&realmSnapshot{
+		fp:       fp,
+		navPaths: append([]string(nil), g.Nodes()...),
+		graph:    g,
+		manifest: entries,
+	})
+}
+
+// current returns the currently published snapshot. Never nil after
+// construction.
+func (s *snapshotStore) current() *realmSnapshot {
+	return s.ptr.Load()
+}
+
+// ensureFresh computes the quiet-window fingerprint and, when it differs from
+// the published snapshot's fp, triggers a rebuild. It is the single accessor
+// shared by the ticker, lazy per-request validation, and the startup warm
+// (SC: "ticker, lazy request-path validation, and startup warm all call the
+// same snapshot accessor"). Returns the (possibly just-published) snapshot
+// and the changed-relpath manifest diff (nil when no rebuild occurred).
+func (s *snapshotStore) ensureFresh() (*realmSnapshot, []string) {
+	entries, fp := s.fingerprint()
+	cur := s.current()
+	if cur.graph != nil && cur.fp == fp {
+		return cur, nil
+	}
+	if !s.rebuilding.CompareAndSwap(false, true) {
+		// A rebuild for this staleness signal is already in flight — skip
+		// rather than block. The caller observes the current snapshot; a
+		// later call catches the change once the in-flight rebuild lands.
+		return cur, nil
+	}
+	defer s.rebuilding.Store(false)
+
+	return s.rebuild(entries, fp)
+}
+
+// rebuild walks nav paths and the link graph (BuildLinkGraph — content
+// reads), diffs the new manifest against the prior snapshot's, and publishes
+// the result via one atomic pointer swap. entries/fp are the fingerprint
+// already computed by the caller so this does not re-walk to get them.
+//
+// A file that vanishes between the fingerprint walk and BuildLinkGraph's
+// content read is skipped for this rebuild without error (BuildLinkGraph
+// already continues past a read failure); it disappears from navPaths/graph
+// for this pass and, if truly gone, stays gone on the next fingerprint walk —
+// if it reappears, the next rebuild picks it up (SC5).
+func (s *snapshotStore) rebuild(entries map[string]fileManifestEntry, fp string) (*realmSnapshot, []string) {
+	s.rebuildCalls.Add(1)
+
+	g := BuildLinkGraph(s.root)
+	navPaths := append([]string(nil), g.Nodes()...)
+
+	prev := s.current()
+	changed := diffManifest(prev.manifest, entries)
+
+	next := &realmSnapshot{fp: fp, navPaths: navPaths, graph: g, manifest: entries}
+	s.ptr.Store(next)
+	return next, changed
+}
+
+// fingerprint performs the quiet-window-filtered, stat-only manifest walk:
+// every non-hidden file under root (same shouldSkipDir/hiddenFile filters as
+// BuildLinkGraph, so the fingerprint tracks exactly what the graph depends
+// on), excluding any file whose mtime falls within the quiet window of now.
+// No file content is read — cheap enough to run on every ensureFresh call,
+// including a zero-subscriber tick (SC4).
+func (s *snapshotStore) fingerprint() (map[string]fileManifestEntry, string) {
+	now := time.Now()
+	entries := make(map[string]fileManifestEntry)
+	_ = filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if path != s.root && shouldSkipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if hiddenFile(d.Name()) {
+			return nil
+		}
+		rel, relErr := filepath.Rel(s.root, path)
+		if relErr != nil {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			// Vanished between directory listing and stat — skip for this
+			// walk without error; a later walk reflects whatever is there.
+			return nil
+		}
+		if now.Sub(info.ModTime()) < s.quietWindow {
+			return nil
+		}
+		entries[filepath.ToSlash(rel)] = fileManifestEntry{
+			size:        info.Size(),
+			modUnixNano: info.ModTime().UnixNano(),
+		}
+		return nil
+	})
+
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		e := entries[k]
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(strconv.FormatInt(e.size, 10)))
+		h.Write([]byte{0})
+		h.Write([]byte(strconv.FormatInt(e.modUnixNano, 10)))
+		h.Write([]byte{'\n'})
+	}
+	return entries, hex.EncodeToString(h.Sum(nil))
+}
+
+// diffManifest returns the sorted set of relpaths added, edited (size or
+// mtime differs), or removed between prev and next. Either map may be nil
+// (the store's first rebuild has no prior manifest) — every entry in next is
+// then reported as changed.
+func diffManifest(prev, next map[string]fileManifestEntry) []string {
+	var changed []string
+	for path, n := range next {
+		if p, ok := prev[path]; !ok || p != n {
+			changed = append(changed, path)
+		}
+	}
+	for path := range prev {
+		if _, ok := next[path]; !ok {
+			changed = append(changed, path)
+		}
+	}
+	sort.Strings(changed)
+	return changed
+}

--- a/atomic/internal/serve/snapshot_internal_test.go
+++ b/atomic/internal/serve/snapshot_internal_test.go
@@ -1,0 +1,276 @@
+package serve
+
+// Tests for snapshotStore — the CP1 realm snapshot core.
+//
+// Why internal: snapshotStore, realmSnapshot, and their methods are
+// unexported (an implementation detail behind the graphDataCache/handler
+// seam), so these tests live in package serve rather than serve_test.
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// writeSnapFile creates a file at root/relPath (making parent dirs), with an
+// mtime old enough to be outside any reasonable quiet window used in these
+// tests — so a freshly-written fixture file is immediately eligible for the
+// fingerprint manifest unless a test explicitly wants otherwise.
+func writeSnapFile(t *testing.T, root, relPath, content string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(abs, old, old); err != nil {
+		t.Fatalf("chtimes %s: %v", abs, err)
+	}
+}
+
+// TestEnsureFresh_OneWalkPopulatesFpNavPathsAndGraph verifies SC1: a single
+// ensureFresh rebuild populates the fingerprint, nav paths, and link graph
+// together, and current() exposes all three from one consistent snapshot.
+func TestEnsureFresh_OneWalkPopulatesFpNavPathsAndGraph(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "alpha.md", "# Alpha\n\nSee [beta](beta.md).\n")
+	writeSnapFile(t, root, "beta.md", "# Beta\n\nNo links.\n")
+
+	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+
+	snap, _ := store.ensureFresh()
+
+	if snap.fp == "" {
+		t.Error("ensureFresh: expected a non-empty fingerprint after the first rebuild")
+	}
+	if len(snap.navPaths) != 2 {
+		t.Errorf("ensureFresh: expected 2 nav paths, got %d: %v", len(snap.navPaths), snap.navPaths)
+	}
+	if snap.graph == nil {
+		t.Fatal("ensureFresh: expected a non-nil graph after the first rebuild")
+	}
+	if !snap.graph.Has("alpha.md") || !snap.graph.Has("beta.md") {
+		t.Errorf("ensureFresh: graph missing expected nodes: %v", snap.graph.Nodes())
+	}
+	// current() must expose the exact same published snapshot (single atomic
+	// pointer swap — no separate state to fall out of sync).
+	if cur := store.current(); cur != snap {
+		t.Error("current() must return the same snapshot ensureFresh just published")
+	}
+}
+
+// TestEnsureFresh_QuietWindowExcludesRecentFile verifies SC4: a file whose
+// mtime is within the quiet window of now does not flip the fingerprint, so
+// it is not (yet) picked up by a rebuild; once its mtime ages past the
+// window, the next ensureFresh call detects it.
+func TestEnsureFresh_QuietWindowExcludesRecentFile(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "stable.md", "# Stable\n")
+
+	quietWindow := 100 * time.Millisecond
+	store := newSnapshotStore(root, defaultTickInterval, quietWindow)
+
+	snap1, _ := store.ensureFresh()
+	if len(snap1.navPaths) != 1 {
+		t.Fatalf("baseline: expected 1 nav path, got %d: %v", len(snap1.navPaths), snap1.navPaths)
+	}
+	fp1 := snap1.fp
+
+	// Write a brand-new file — its mtime is "now", inside the quiet window.
+	if err := os.WriteFile(filepath.Join(root, "fresh.md"), []byte("# Fresh\n"), 0o644); err != nil {
+		t.Fatalf("write fresh.md: %v", err)
+	}
+
+	snap2, changed2 := store.ensureFresh()
+	if snap2.fp != fp1 {
+		t.Errorf("quiet window: fingerprint changed on a file still inside the quiet window (fp1=%q fp2=%q)", fp1, snap2.fp)
+	}
+	if len(changed2) != 0 {
+		t.Errorf("quiet window: expected no changed relpaths yet, got %v", changed2)
+	}
+	if len(snap2.navPaths) != 1 {
+		t.Errorf("quiet window: fresh.md must not appear in nav paths yet, got %v", snap2.navPaths)
+	}
+
+	// Age past the quiet window: the next ensureFresh call must detect it.
+	time.Sleep(quietWindow + 50*time.Millisecond)
+
+	snap3, changed3 := store.ensureFresh()
+	if snap3.fp == fp1 {
+		t.Error("quiet window: fingerprint must change once fresh.md ages past the quiet window")
+	}
+	foundChanged := false
+	for _, c := range changed3 {
+		if c == "fresh.md" {
+			foundChanged = true
+		}
+	}
+	if !foundChanged {
+		t.Errorf("quiet window: expected fresh.md in the changed set, got %v", changed3)
+	}
+	if len(snap3.navPaths) != 2 {
+		t.Errorf("quiet window: expected fresh.md to now appear in nav paths, got %v", snap3.navPaths)
+	}
+}
+
+// TestRebuild_UnreadableFileSkippedWithoutError verifies SC5's contract at the
+// error-handling level: a file that fails to read during rebuild (simulated
+// via a permission-denied file — the same os.ReadFile error path a file
+// vanishing between stat and read would hit) is skipped for that rebuild
+// without aborting it (BuildLinkGraph still discovers its name — file listing
+// needs no read permission — but its content-derived metadata is left unset),
+// and a later rebuild (once the file becomes readable again — standing in for
+// "reappears") picks up its content.
+func TestRebuild_UnreadableFileSkippedWithoutError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skip: running as root ignores file permission bits")
+	}
+
+	root := t.TempDir()
+	writeSnapFile(t, root, "ok.md", "# OK\n")
+	blockedPath := filepath.Join(root, "blocked.md")
+	writeSnapFile(t, root, "blocked.md", "# Blocked\n")
+	if err := os.Chmod(blockedPath, 0o000); err != nil {
+		t.Fatalf("chmod blocked.md: %v", err)
+	}
+	defer os.Chmod(blockedPath, 0o644) //nolint:errcheck // best-effort cleanup
+
+	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+
+	snap, _ := store.ensureFresh()
+	// The rebuild must complete for every other file despite the read failure.
+	if !snap.graph.Has("ok.md") || snap.graph.Meta("ok.md").Title == "" {
+		t.Error("rebuild: the unreadable file must not abort processing of the rest of the rebuild")
+	}
+	// Content-derived metadata for the unreadable file must be unset (its read
+	// failed and was skipped, not substituted with stale or partial data).
+	if title := snap.graph.Meta("blocked.md").Title; title != "" {
+		t.Errorf("rebuild: unreadable file must have no content-derived metadata yet, got title %q", title)
+	}
+
+	// Restore readability and age the mtime so it clears the quiet window,
+	// then force a rebuild: the file's content must now be picked up.
+	if err := os.Chmod(blockedPath, 0o644); err != nil {
+		t.Fatalf("restore chmod: %v", err)
+	}
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(blockedPath, old, old); err != nil {
+		t.Fatalf("chtimes blocked.md: %v", err)
+	}
+
+	snap2, _ := store.ensureFresh()
+	if title := snap2.graph.Meta("blocked.md").Title; title == "" {
+		t.Error("rebuild: a file that becomes readable again must have its content picked up on a later rebuild")
+	}
+}
+
+// TestEnsureFresh_ConcurrentCallersCollapseToOneRebuild verifies SC7:
+// concurrent ensureFresh calls racing a stale fingerprint collapse to exactly
+// one rebuild, gated by the rebuild-in-flight CAS, not by the computed
+// fingerprint value.
+func TestEnsureFresh_ConcurrentCallersCollapseToOneRebuild(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "a.md", "# A\n")
+
+	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+	// Baseline rebuild so the store has a published snapshot already.
+	store.ensureFresh()
+
+	// Change the realm so the next ensureFresh call observes staleness.
+	writeSnapFile(t, root, "b.md", "# B\n")
+
+	baseline := store.rebuildCalls.Load()
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			store.ensureFresh()
+		}()
+	}
+	wg.Wait()
+
+	got := store.rebuildCalls.Load() - baseline
+	if got != 1 {
+		t.Errorf("concurrent ensureFresh: expected exactly 1 rebuild for the staleness signal, got %d", got)
+	}
+
+	// The realm state must reflect the winning rebuild regardless of which
+	// goroutine performed it.
+	if !store.current().graph.Has("b.md") {
+		t.Error("concurrent ensureFresh: the published snapshot must reflect the rebuild that ran")
+	}
+}
+
+// TestDiffManifest_AddedEditedRemoved verifies the manifest diff used to
+// compute the changed-relpath set consumed by checkpoint 3's event payload.
+func TestDiffManifest_AddedEditedRemoved(t *testing.T) {
+	prev := map[string]fileManifestEntry{
+		"unchanged.md": {size: 10, modUnixNano: 100},
+		"edited.md":    {size: 10, modUnixNano: 100},
+		"removed.md":   {size: 5, modUnixNano: 50},
+	}
+	next := map[string]fileManifestEntry{
+		"unchanged.md": {size: 10, modUnixNano: 100},
+		"edited.md":    {size: 20, modUnixNano: 200},
+		"added.md":     {size: 3, modUnixNano: 300},
+	}
+
+	got := diffManifest(prev, next)
+	want := []string{"added.md", "edited.md", "removed.md"}
+
+	if len(got) != len(want) {
+		t.Fatalf("diffManifest: got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("diffManifest[%d]: got %q, want %q (full: %v)", i, got[i], w, got)
+		}
+	}
+}
+
+// TestSnapshotStore_Seed verifies that seed() publishes the given graph
+// as-is (no rebuild) with a fingerprint reflecting current on-disk state, so
+// a caller that already built a graph can hand ongoing revalidation to the
+// store without discarding what it built.
+func TestSnapshotStore_Seed(t *testing.T) {
+	root := t.TempDir()
+	writeSnapFile(t, root, "page.md", "# Page\n")
+
+	// A graph built from a different (empty) root — proves seed() publishes
+	// exactly the graph it was given, not one rebuilt from root.
+	emptyRoot := t.TempDir()
+	injected := BuildLinkGraph(emptyRoot)
+
+	store := newSnapshotStore(root, defaultTickInterval, defaultQuietWindow)
+	store.seed(injected)
+
+	cur := store.current()
+	if cur.graph != injected {
+		t.Error("seed: current().graph must be the exact injected graph, not a rebuilt one")
+	}
+	if len(cur.navPaths) != 0 {
+		t.Errorf("seed: navPaths must come from the injected (empty) graph, got %v", cur.navPaths)
+	}
+	if cur.fp == "" {
+		t.Error("seed: fingerprint must be computed from current on-disk state, not left empty")
+	}
+
+	// A subsequent ensureFresh call with nothing changed on disk must not
+	// trigger a rebuild (the seeded fp must match a fresh fingerprint walk).
+	baseline := store.rebuildCalls.Load()
+	snap, _ := store.ensureFresh()
+	if store.rebuildCalls.Load() != baseline {
+		t.Error("seed: an unchanged realm must not trigger a rebuild after seeding")
+	}
+	if snap.graph != injected {
+		t.Error("seed: ensureFresh must keep returning the seeded graph until the realm actually changes")
+	}
+}

--- a/atomic/internal/serve/templates/layout.html
+++ b/atomic/internal/serve/templates/layout.html
@@ -1042,6 +1042,14 @@
             <kbd class="search-trigger-kbd">⌘K</kbd>
         </button>
     </div>
+    <!-- Live-reload connectivity indicator: reflects the /events EventSource's
+         readyState (live / reconnecting / disconnected). Painted by the
+         live-reload boot script below; the initial markup is the pre-connect
+         state so there is no flash of an unstyled dot before JS runs. -->
+    <span id="conn-indicator" class="conn-indicator" data-conn-state="reconnecting" title="Live reload: connecting…">
+        <span class="conn-dot" aria-hidden="true"></span>
+        <span class="conn-label">connecting…</span>
+    </span>
     <!-- Network / graph view toggle: shows/hides the full system graph -->
     <button class="theme-toggle" id="btn-graph" type="button"
             aria-label="Network view — toggle full graph" title="Network view"
@@ -1216,12 +1224,24 @@
      opened from a scrolled position would otherwise land mid-document. Keyed on
      the swap target so only content swaps reset (intel/rail swaps are left
      alone); history restores swap <body>, not #main-pane, so Back/Forward keep
-     their restored position. -->
+     their restored position.
+
+     A swap the live-reload script triggered carries an `HX-Live-Swap` request
+     header (set via the `headers` option on the triggering `htmx.ajax()` call,
+     below) so it can be told apart from ordinary navigation here. The header
+     lives on `evt.detail.ctx.request` — a fresh object per in-flight request,
+     not a DOM attribute on the shared target — so two swaps racing on the same
+     target (an ordinary nav vs. a live refetch, or two overlapping live
+     refetches) can never read or clear each other's marker; each swap's
+     `htmx:after:swap` event sees only its own request's headers. -->
 <script>
 document.addEventListener('htmx:after:swap', function(evt) {
   var ctx = evt.detail && evt.detail.ctx;
   var tgt = ctx && ctx.target;
-  if (tgt && tgt.id === 'main-pane') { tgt.scrollTop = 0; }
+  if (!tgt) { return; }
+  var headers = ctx.request && ctx.request.headers;
+  if (headers && headers['HX-Live-Swap']) { return; }
+  if (tgt.id === 'main-pane') { tgt.scrollTop = 0; }
 });
 </script>
 
@@ -1628,6 +1648,119 @@ document.addEventListener('htmx:after:swap', function(evt) {
     e.preventDefault();
     htmx.ajax('GET', '/page/' + folder + '/', { target: '#main-pane', swap: 'innerHTML' });
   });
+}());
+</script>
+
+<!-- Live reload (CP4): EventSource boot, page-mode reconcile, connectivity
+     indicator. Bound once via the same boot-guard idiom the search dialog
+     script uses (window.__atomicSearchBooted, above): a history-restore body
+     swap re-runs this inline script, but window.__atomicEventsBooted stops it
+     re-connecting — the original EventSource and its closure survive the swap
+     untouched (htmx 4 history-restore replaces <body>'s innerHTML, not the
+     document, so the connection is never torn down).
+
+     Dispatch point for checkpoint 5 (system-mode graph diff/patch): every
+     processed {fp, changed} message is re-broadcast as an `atomic:live-reload`
+     DOM CustomEvent (detail = the message) — CP5 registers its own
+     `document.addEventListener('atomic:live-reload', …)` alongside
+     pageModeReconcile below without touching this script. -->
+<script>
+(function() {
+  if (window.__atomicEventsBooted) { return; }
+  window.__atomicEventsBooted = true;
+
+  var lastSeenFp = null;
+
+  // ── connectivity indicator ──────────────────────────────────────────────
+  var connState = 'reconnecting'; // 'live' | 'reconnecting' | 'disconnected'
+  var connLabels = { live: 'live', reconnecting: 'connecting…', disconnected: 'disconnected' };
+
+  // Re-applies connState to the current #conn-indicator node. Called on every
+  // htmx:after:swap (not just state changes) because a full-body swap (history
+  // restore) replaces the indicator with a fresh, unpainted DOM node — the
+  // EventSource itself survives the swap, only its visual readout needs resync.
+  function paintConnIndicator() {
+    var el = document.getElementById('conn-indicator');
+    if (!el) { return; }
+    el.setAttribute('data-conn-state', connState);
+    el.title = 'Live reload: ' + connLabels[connState];
+    var label = el.querySelector('.conn-label');
+    if (label) { label.textContent = connLabels[connState]; }
+  }
+
+  function setConnState(next) {
+    connState = next;
+    paintConnIndicator();
+  }
+
+  document.addEventListener('htmx:after:swap', paintConnIndicator);
+
+  // ── page-mode reconcile (spec Flow 3) ───────────────────────────────────
+
+  // currentDisplayedRelpath returns the realm-root-relative path of the page
+  // currently shown in #main-pane, or '' when main-pane holds anything else
+  // (system graph, 404, search page) — the pane-refetch step below is a no-op
+  // in that case, which is also how it avoids clobbering the system graph
+  // without a separate mode check.
+  function currentDisplayedRelpath() {
+    var pc = document.querySelector('#main-pane #page-content[data-relpath]');
+    return pc ? pc.getAttribute('data-relpath') : '';
+  }
+
+  // liveSwap tags the request with an HX-Live-Swap header so the scroll-reset
+  // listener (above) can recognize this specific swap by its own request
+  // context rather than a shared DOM attribute, then performs the refetch
+  // through htmx's JS API so any OOB fragments in the response (breadcrumb,
+  // rail loader) still process.
+  function liveSwap(url, target) {
+    if (!target) { return; }
+    htmx.ajax('GET', url, { target: target, swap: 'innerHTML', headers: { 'HX-Live-Swap': '1' } });
+  }
+
+  function pageModeReconcile(ev) {
+    liveSwap('/nav?live=1', document.getElementById('nav-pane'));
+
+    var changed = ev.changed; // absent → cap exceeded → treat everything as changed
+    var rel = currentDisplayedRelpath();
+    if (rel && (!changed || changed.indexOf(rel) !== -1)) {
+      // The /page/<rel> fragment response carries the rail's OOB loader
+      // (context_handler.go pageWithGraphFragmentTmplStr), which itself
+      // hx-trigger="load"s GET /rail/<rel> — a separate rail refetch here
+      // would just re-request what that loader already triggers.
+      liveSwap('/page/' + rel, document.getElementById('main-pane'));
+    }
+  }
+
+  document.addEventListener('atomic:live-reload', function(e) { pageModeReconcile(e.detail); });
+
+  // ── EventSource boot (spec Flow 2: subscribe) ───────────────────────────
+  var es = new EventSource('/events');
+
+  es.onopen = function() { setConnState('live'); };
+
+  // onerror fires both for a genuine terminal failure and for the browser's
+  // built-in retry attempts; readyState tells them apart (CLOSED only after
+  // the browser gives up, which does not happen for a plain reconnect loop).
+  es.onerror = function() {
+    setConnState(es.readyState === EventSource.CLOSED ? 'disconnected' : 'reconnecting');
+  };
+
+  es.onmessage = function(msgEvt) {
+    var ev;
+    try { ev = JSON.parse(msgEvt.data); } catch (e) { return; }
+    // The resync push (Flow 2 step 3) is always the first message a connection
+    // receives, sent unconditionally regardless of whether anything changed
+    // since the page was rendered. lastSeenFp starts null, so treat this first
+    // message as fp-seeding only — dispatching it would spuriously refetch
+    // freshly rendered content on every page load.
+    if (lastSeenFp === null) {
+      lastSeenFp = ev.fp;
+      return;
+    }
+    if (ev.fp === lastSeenFp) { return; } // outer no-op guard (Flow 3 step 2)
+    document.dispatchEvent(new CustomEvent('atomic:live-reload', { detail: ev }));
+    lastSeenFp = ev.fp; // Flow 3 step 7
+  };
 }());
 </script>
 

--- a/atomic/internal/serve/templates/layout.html
+++ b/atomic/internal/serve/templates/layout.html
@@ -708,6 +708,8 @@
     (function() {
       var currentPage = null;       // last /page/ URL loaded (for the "back to page" toggle)
       var VIEW_DEBOUNCE_MS = 250;   // how long after the last zoom/pan before writing the URL
+      var systemLayoutCacheKey = null; // current IndexedDB key (CP5: hash of the mounted element-id set)
+      var systemMountInFlight = false; // CP5: true from mount start until window.__systemCy is set (or the mount fails) — guards against a live-reload event racing a second concurrent mountSystemGraph
 
       function inSystemMode() { return document.body.classList.contains('mode-system'); }
 
@@ -729,6 +731,7 @@
         updateGraphBtnState(false);
         AtomicGraphUI.hidePreviewCard();
         AtomicGraphUI.closePageModal();
+        systemLayoutCacheKey = null;
       }
 
       // Track current page + clean up system mode whenever #main-pane swaps. htmx 4:
@@ -815,14 +818,18 @@
         mainPane.appendChild(legend);
       }
 
-      // ── Layout cache (IndexedDB, keyed by the realm sha256 fingerprint) ────────
-      // The ELK 'stress' layout is the real cost of opening the Network View — it
-      // recomputes node positions every mount (the Cytoscape instance is destroyed
-      // on exit). We cache the computed positions in IndexedDB keyed by the server's
-      // filesystem fingerprint (the X-Graph-Fingerprint header — a sha256 over the
-      // realm that changes on ANY edit, so it invalidates correctly). Subsequent
-      // opens replay the saved positions with a 'preset' layout (no algorithm) so
-      // the graph appears instantly, and IndexedDB persists across browser sessions.
+      // ── Layout cache (IndexedDB, keyed by the mounted element-id set) ───────────
+      // The ELK 'stress' / cola layout is the real cost of opening the Network View
+      // — it recomputes node positions every mount (the Cytoscape instance is
+      // destroyed on exit). We cache the computed positions in IndexedDB keyed by a
+      // hash of the sorted ids of every node + edge currently mounted (not the realm
+      // fingerprint — CP5: a live-reload patch changes the mounted set without a
+      // full remount, so the key must track what's actually on screen). Subsequent
+      // opens of the same graph shape replay the saved positions with a 'preset'
+      // layout (no algorithm) so the graph appears instantly; IndexedDB persists
+      // across browser sessions. Every re-key — cold mount, degenerate-fallback
+      // remount, or incremental patch — prunes the entry for the key it
+      // superseded, if any, so stale shapes don't accumulate.
       var LAYOUT_DB = 'atomic-serve', LAYOUT_STORE = 'graph-layout';
 
       function idbOpen() {
@@ -854,6 +861,36 @@
           db.transaction(LAYOUT_STORE, 'readwrite').objectStore(LAYOUT_STORE).put(positions, key);
         }).catch(function() {});
       }
+      function deleteCachedLayout(key) {
+        if (!key) { return; }
+        idbOpen().then(function(db) {
+          db.transaction(LAYOUT_STORE, 'readwrite').objectStore(LAYOUT_STORE).delete(key);
+        }).catch(function() {});
+      }
+
+      // collectElementIds flattens a /graph/data response into one id array
+      // (nodes + edges) for hashing.
+      function collectElementIds(elems) {
+        var ids = [];
+        (elems.nodes || []).forEach(function(n) { if (n.data && n.data.id != null) { ids.push(n.data.id); } });
+        (elems.edges || []).forEach(function(e) { if (e.data && e.data.id != null) { ids.push(e.data.id); } });
+        return ids;
+      }
+
+      // elementIdSetHash derives a deterministic IndexedDB key from a set of
+      // element ids: sort (order-independent), join, FNV-1a hash. Not a
+      // cryptographic digest — uniqueness across graph shapes is all that's
+      // needed, so a synchronous string hash avoids an async crypto.subtle
+      // round trip in the mount/reconcile chain.
+      function elementIdSetHash(ids) {
+        var str = ids.slice().sort().join('|'); // separator avoids a false collision between differently-split concatenations of the same ids
+        var h = 0x811c9dc5;
+        for (var i = 0; i < str.length; i++) {
+          h ^= str.charCodeAt(i);
+          h = (h * 0x01000193) >>> 0;
+        }
+        return 'idset-' + h.toString(16);
+      }
 
       // Mount the system graph into the [data-system-graph] container delivered by
       // the /graph fragment. Guarded against double-mount (a dataset flag).
@@ -861,6 +898,7 @@
         if (container.dataset.systemMounted === '1') { return; }
         if (typeof cytoscape === 'undefined') { return; }
         container.dataset.systemMounted = '1';
+        systemMountInFlight = true;
 
         var mainPane = document.getElementById('main-pane');
         document.body.classList.add('mode-system');
@@ -871,12 +909,18 @@
           if (l) { l.remove(); }
         }
 
-        var graphFP = null; // realm fingerprint from the response header (cache key)
         fetch('/graph/data')
-          .then(function(r) { graphFP = r.headers.get('X-Graph-Fingerprint'); return r.json(); })
+          .then(function(r) { return r.json(); })
           .then(function(elems) {
-            // Look up a cached layout for this exact realm state, then mount.
-            return loadCachedLayout(graphFP).then(function(cachedPos) { return { elems: elems, cachedPos: cachedPos }; });
+            // Look up a cached layout for this exact mounted-element-id shape, then mount.
+            // Capture the outgoing key before overwriting it — the degenerate-fallback
+            // remount path (fullSystemRelayout) leaves systemLayoutCacheKey pointing at
+            // the pre-fallback shape, so its IndexedDB entry must be pruned here too
+            // (mirrors rekeyLayoutCache's incremental-patch prune, SC20).
+            var supersededKey = systemLayoutCacheKey;
+            systemLayoutCacheKey = elementIdSetHash(collectElementIds(elems));
+            if (supersededKey && supersededKey !== systemLayoutCacheKey) { deleteCachedLayout(supersededKey); }
+            return loadCachedLayout(systemLayoutCacheKey).then(function(cachedPos) { return { elems: elems, cachedPos: cachedPos }; });
           })
           .then(function(bundle) {
             var elems = bundle.elems;
@@ -911,6 +955,7 @@
               maxZoom: 2.2
             });
             window.__systemCy = cy;
+            systemMountInFlight = false;
 
             var saved = readViewFromURL();
             var recording = false; // ignore programmatic initial view; record user changes after
@@ -955,12 +1000,12 @@
             // lets continuous physics and the layout cache coexist).
             var saveTimer = null;
             function scheduleSave() {
-              if (!graphFP) { return; }
+              if (!systemLayoutCacheKey) { return; }
               clearTimeout(saveTimer);
               saveTimer = setTimeout(function() {
                 var positions = {};
                 cy.nodes().forEach(function(n) { var p = n.position(); positions[n.id()] = { x: p.x, y: p.y }; });
-                saveCachedLayout(graphFP, positions);
+                saveCachedLayout(systemLayoutCacheKey, positions);
               }, 800);
             }
 
@@ -988,11 +1033,157 @@
             });
           })
           .catch(function(e) {
+            systemMountInFlight = false;
             var l = mainPane.querySelector('.system-graph-loading');
             if (l) { l.textContent = 'Could not render the system graph.'; }
             console.error('system-graph /graph/data:', e);
           });
       }
+
+      // ── System-mode reconcile (CP5, spec Flow 4) ────────────────────────────
+      // Registers on CP4's `atomic:live-reload` dispatch, which only fires once
+      // the fp has already been confirmed to differ — no re-check needed here.
+      // No boot guard: this whole script lives in <head>, which htmx never
+      // swaps, so it runs exactly once per real page load (unlike the <body>
+      // live-reload script below, which guards against a history-restore
+      // body-innerHTML re-execution).
+
+      // seedPositionNear places a newly added node near a neighbor already on
+      // screen (a survivor, or an added node placed earlier in the same batch)
+      // so the scoped cola pass below refines a local cluster instead of
+      // scattering new nodes across the canvas. Falls back to the viewport
+      // center when no such neighbor is found yet.
+      function seedPositionNear(cy, nodeId, addedEdges, fallbackCenter) {
+        for (var i = 0; i < addedEdges.length; i++) {
+          var d = addedEdges[i].data;
+          if (!d) { continue; }
+          var other = d.source === nodeId ? d.target : (d.target === nodeId ? d.source : null);
+          if (!other) { continue; }
+          var neighbor = cy.getElementById(other);
+          if (neighbor.length && neighbor.isNode()) {
+            var p = neighbor.position();
+            return { x: p.x + (Math.random() - 0.5) * 40, y: p.y + (Math.random() - 0.5) * 40 };
+          }
+        }
+        return { x: fallbackCenter.x, y: fallbackCenter.y };
+      }
+
+      // fullSystemRelayout is the degenerate-fallback path: tear down and
+      // remount from scratch via the existing cold-mount flow (its own fetch,
+      // cache lookup, and cola/preset layout) instead of duplicating that logic
+      // here. Used both when the diff exceeds the 50% threshold and when no
+      // Cytoscape instance is mounted to diff against.
+      function fullSystemRelayout(container) {
+        if (!container) { container = document.querySelector('[data-system-graph]'); }
+        if (!container) { return; }
+        if (window.__systemCy) { try { window.__systemCy.destroy(); } catch (e) {} window.__systemCy = null; }
+        container.dataset.systemMounted = '';
+        mountSystemGraph(container);
+      }
+
+      // rekeyLayoutCache re-derives the IndexedDB key from the just-patched cy
+      // instance's element ids, saves the current positions under it, and
+      // prunes the entry for the key it superseded (SC20).
+      function rekeyLayoutCache(cy) {
+        var ids = [];
+        cy.nodes().forEach(function(n) { ids.push(n.id()); });
+        cy.edges().forEach(function(e) { ids.push(e.id()); });
+        var newKey = elementIdSetHash(ids);
+        var oldKey = systemLayoutCacheKey;
+        if (newKey === oldKey) { return; }
+        var positions = {};
+        cy.nodes().forEach(function(n) { var p = n.position(); positions[n.id()] = { x: p.x, y: p.y }; });
+        saveCachedLayout(newKey, positions);
+        if (oldKey) { deleteCachedLayout(oldKey); }
+        systemLayoutCacheKey = newKey;
+      }
+
+      // systemModeReconcile diffs a fresh /graph/data response against the
+      // mounted Cytoscape instance by element id (nodes AND edges) and either
+      // patches in place or falls back to a full relayout above the 50%
+      // threshold. No-op outside system mode — the page-mode reconcile (body
+      // script, below) owns everything else.
+      function systemModeReconcile() {
+        if (!inSystemMode()) { return; }
+        // An initial mount's /graph/data fetch is still in flight — it will render
+        // the current state on its own once it resolves, so no-op rather than race
+        // fullSystemRelayout into a second concurrent mountSystemGraph on the same
+        // container (window.__systemCy isn't set yet during this stretch, so the
+        // no-instance-mounted check below can't tell "still mounting" from "torn down").
+        if (systemMountInFlight) { return; }
+        var container = document.querySelector('[data-system-graph]');
+        var cy = window.__systemCy;
+        if (!cy || !container) { fullSystemRelayout(container); return; }
+
+        fetch('/graph/data')
+          .then(function(r) { return r.json(); })
+          .then(function(elems) {
+            var freshNodes = elems.nodes || [];
+            var freshEdges = elems.edges || [];
+
+            var mountedNodeIds = {}, mountedEdgeIds = {};
+            cy.nodes().forEach(function(n) { mountedNodeIds[n.id()] = true; });
+            cy.edges().forEach(function(e) { mountedEdgeIds[e.id()] = true; });
+            var mountedTotal = cy.nodes().length + cy.edges().length;
+
+            var freshNodeIds = {}, freshEdgeIds = {};
+            freshNodes.forEach(function(n) { if (n.data) { freshNodeIds[n.data.id] = true; } });
+            freshEdges.forEach(function(e) { if (e.data) { freshEdgeIds[e.data.id] = true; } });
+
+            var addedNodes = freshNodes.filter(function(n) { return n.data && !mountedNodeIds[n.data.id]; });
+            var addedEdges = freshEdges.filter(function(e) { return e.data && !mountedEdgeIds[e.data.id]; });
+            var removedIds = Object.keys(mountedNodeIds).filter(function(id) { return !freshNodeIds[id]; })
+              .concat(Object.keys(mountedEdgeIds).filter(function(id) { return !freshEdgeIds[id]; }));
+
+            var changedCount = addedNodes.length + addedEdges.length + removedIds.length;
+            var ratio = mountedTotal > 0 ? changedCount / mountedTotal : 1;
+            if (ratio > 0.5) { fullSystemRelayout(container); return; }
+
+            var toRemove = cy.collection();
+            removedIds.forEach(function(id) { toRemove = toRemove.union(cy.getElementById(id)); });
+            cy.remove(toRemove);
+
+            // Degree over the fresh full edge set so a brand-new hub sizes
+            // correctly on first appearance (mirrors the cold-mount calc above).
+            var deg = {};
+            freshEdges.forEach(function(e) {
+              var s = e.data && e.data.source, t = e.data && e.data.target;
+              if (s != null) { deg[s] = (deg[s] || 0) + 1; }
+              if (t != null) { deg[t] = (deg[t] || 0) + 1; }
+            });
+
+            var extent = cy.extent();
+            var fallbackCenter = { x: (extent.x1 + extent.x2) / 2, y: (extent.y1 + extent.y2) / 2 };
+
+            var addedCollection = cy.collection();
+            addedNodes.forEach(function(n) {
+              var pos = seedPositionNear(cy, n.data.id, addedEdges, fallbackCenter);
+              n.data.deg = Math.min(deg[n.data.id] || 0, 16);
+              addedCollection = addedCollection.union(cy.add({ group: 'nodes', data: n.data, position: pos }));
+            });
+            addedEdges.forEach(function(e) {
+              addedCollection = addedCollection.union(cy.add({ group: 'edges', data: e.data, classes: e.classes }));
+            });
+
+            // Scoped pass on the new collection only — cytoscape-cola drops any
+            // link whose endpoint sits outside `eles` (its nonparentNodes
+            // filter), so pre-existing nodes/edges are neither moved nor
+            // considered; `fit: false` also suppresses cola's own internal
+            // cy.fit() call, on top of never calling cy.fit() ourselves.
+            if (addedCollection.length) {
+              addedCollection.layout({
+                name: 'cola', fit: false, animate: true, randomize: false,
+                avoidOverlap: true, nodeSpacing: function() { return 8; },
+                edgeLength: 100, maxSimulationTime: 1500, infinite: false
+              }).run();
+            }
+
+            rekeyLayoutCache(cy);
+          })
+          .catch(function(e) { console.error('system-graph reconcile /graph/data:', e); });
+      }
+
+      document.addEventListener('atomic:live-reload', systemModeReconcile);
 
       // Delegated mount: fires whenever the /graph fragment ([data-system-graph])
       // lands in #main-pane (button click, refresh, Back/Forward).

--- a/atomic/internal/serve/templates/layout.html
+++ b/atomic/internal/serve/templates/layout.html
@@ -710,6 +710,7 @@
       var VIEW_DEBOUNCE_MS = 250;   // how long after the last zoom/pan before writing the URL
       var systemLayoutCacheKey = null; // current IndexedDB key (CP5: hash of the mounted element-id set)
       var systemMountInFlight = false; // CP5: true from mount start until window.__systemCy is set (or the mount fails) — guards against a live-reload event racing a second concurrent mountSystemGraph
+      var systemMountAbort = null; // F-4: AbortController for the mount's in-flight /graph/data fetch — teardownSystemGraph aborts it so a stale fetch can't outlive a navigate-away and clobber a later mount's state
 
       function inSystemMode() { return document.body.classList.contains('mode-system'); }
 
@@ -726,6 +727,14 @@
       // dismiss any open card/modal. Called when #main-pane settles with non-graph
       // content (nav click, node "open full page", Back to a page, etc.).
       function teardownSystemGraph() {
+        // Cleared here, synchronously, rather than left for the abandoned mount's
+        // own (async) fetch chain to clear: that chain's bail branches check
+        // ownership (systemMountAbort === their own controller) before touching
+        // ANY shared state, so once torn down they must no-op even for this flag —
+        // otherwise a stale mount's late-settling chain could clear it out from
+        // under a fresh mount that started in the meantime.
+        systemMountInFlight = false;
+        if (systemMountAbort) { systemMountAbort.abort(); systemMountAbort = null; }
         if (window.__systemCy) { try { window.__systemCy.destroy(); } catch (e) {} window.__systemCy = null; }
         document.body.classList.remove('mode-system');
         updateGraphBtnState(false);
@@ -904,14 +913,30 @@
         document.body.classList.add('mode-system');
         updateGraphBtnState(true);
 
+        // F-4: this mount's own controller — passed to fetch so teardownSystemGraph's
+        // abort() actually cancels the in-flight network request. isCurrentMount is
+        // the real guard against a stale mount's chain settling late and clobbering
+        // a fresh one: `signal.aborted` alone only covers the case where THIS mount
+        // was the one aborted, not "some later mount has since taken over
+        // systemMountAbort" — ownership (=== the live systemMountAbort) covers both.
+        var abortController = new AbortController();
+        systemMountAbort = abortController;
+        var signal = abortController.signal;
+        function isCurrentMount() { return systemMountAbort === abortController; }
+
         function clearSystemLoading() {
           var l = mainPane.querySelector('.system-graph-loading');
           if (l) { l.remove(); }
         }
 
-        fetch('/graph/data')
+        fetch('/graph/data', { signal: signal })
           .then(function(r) { return r.json(); })
           .then(function(elems) {
+            // Superseded (torn down and/or a later mount has since taken ownership
+            // of systemMountAbort) between the fetch settling and this callback
+            // running: bail before touching systemLayoutCacheKey — teardownSystemGraph
+            // already cleared systemMountInFlight, so nothing shared gets touched here.
+            if (!isCurrentMount()) { return null; }
             // Look up a cached layout for this exact mounted-element-id shape, then mount.
             // Capture the outgoing key before overwriting it — the degenerate-fallback
             // remount path (fullSystemRelayout) leaves systemLayoutCacheKey pointing at
@@ -923,6 +948,10 @@
             return loadCachedLayout(systemLayoutCacheKey).then(function(cachedPos) { return { elems: elems, cachedPos: cachedPos }; });
           })
           .then(function(bundle) {
+            // bundle is null when the guard above already bailed, or ownership was
+            // lost during the IndexedDB lookup that followed it — either way, no
+            // Cytoscape instance gets built for a superseded mount.
+            if (!bundle || !isCurrentMount()) { return; }
             var elems = bundle.elems;
             var cachedPos = bundle.cachedPos;
 
@@ -954,6 +983,12 @@
               minZoom: 0.02,
               maxZoom: 2.2
             });
+            // Nothing async happens between the guard above and here (cytoscape's
+            // constructor is synchronous), so ownership cannot have changed in
+            // between — this re-check is an explicit invariant rather than a live
+            // race, kept so a future edit that adds an async step here doesn't
+            // silently reopen the gap.
+            if (!isCurrentMount()) { try { cy.destroy(); } catch (e) {} return; }
             window.__systemCy = cy;
             systemMountInFlight = false;
 
@@ -1033,6 +1068,12 @@
             });
           })
           .catch(function(e) {
+            // Ownership-gated like every branch above: a superseded mount's error
+            // (including its own AbortError from teardownSystemGraph) reports
+            // nothing — there's no loading indicator left in the DOM that's still
+            // this mount's, and systemMountInFlight already reflects the mount
+            // that's actually current.
+            if (!isCurrentMount()) { return; }
             systemMountInFlight = false;
             var l = mainPane.querySelector('.system-graph-loading');
             if (l) { l.textContent = 'Could not render the system graph.'; }

--- a/docs/reference/serve.md
+++ b/docs/reference/serve.md
@@ -128,6 +128,17 @@ Lists every outbound `http(s)` URL across the realm: the URL, the source pages t
 The realm-health view, reachable but no longer the landing page. Renders `wiki.Stale` / `wiki.CheckStaleness` (DRIFT / STALE / STALE bucket) plus aggregate code-index health (worst severity across member repos, naming only repos that need action). No new staleness computation — staleness also surfaces ambiently as badges in the nav. `/healthz` is a separate plain-text liveness probe.
 
 
+## Live reload
+
+While a browser tab is open, `atomic serve` reflects filesystem changes without a restart. The server keeps one realm snapshot (fingerprint, nav paths, link graph) and re-checks it with a stat-only walk every 10 seconds, but only while at least one tab is subscribed to the `/events` stream. With no tabs open the server does no periodic work.
+
+When the realm changes, subscribed tabs receive a push carrying the new fingerprint and the list of changed files. The open page refetches its pane and rail only when the displayed file itself changed; the nav tree refreshes on any change. Scroll position is preserved. In the system graph view, changed nodes and edges are patched in place: existing node positions and your pan/zoom stay put, and only additions get a layout pass. When more than half the graph changes at once, the view falls back to a full re-layout.
+
+Files written moments ago are held back for a short quiet window before they are published, so a tool writing a file incrementally never renders a half-written page. A small indicator in the top bar shows the live connection state: live, reconnecting, or disconnected. Shutting the server down with tabs open exits cleanly and immediately.
+
+Provenance hashing and the full graph JSON stay lazy: they are computed when the system view asks for them, never on the periodic check.
+
+
 ## Theme and visual design
 
 `atomic serve` ships with a light and dark theme, both derived from the same CSS custom-property set.

--- a/docs/spec/atomic-migrate-framework.md
+++ b/docs/spec/atomic-migrate-framework.md
@@ -42,7 +42,7 @@ Ordered registry of idempotent `Migration` steps in a new `atomic/internal/migra
 
 ## Checkpoints
 
-| # | Checkpoint | Files / areas | Agent | Est. files | Verifies |
+| # | Checkpoint | Files/areas | Agent | Est. files | Verifies |
 |---|-----------|--------------|-------|-----------|---------|
 | C1 | `migrate` package: `Migration` type, ordered registry, runner (read version → run steps > recorded → write version), semver reuse | `atomic/internal/migrate/` (new); `atomic/internal/selfupdate/semver.go` (export or add thin exported wrapper) | builder | 3–5 | runner applies only steps with `TargetVersion > recorded`; idempotent re-run changes nothing; semver compare matches `selfupdate` behavior |
 | C2 | Config schema v2: `[install]` table in `internal/config`; `checks_config.go` validation | `atomic/internal/config/` (extend schema); `atomic/internal/doctor/checks_config.go` | builder | 3–5 | `config.toml` with `[install].version` and `[install.artifacts]` round-trips; invalid keys reported; missing `[install]` (pre-framework install) is valid (not an error) |

--- a/docs/spec/challenge-swarm.md
+++ b/docs/spec/challenge-swarm.md
@@ -41,9 +41,9 @@ Adapted from Stanford's STORM: perspective-diverse agents grounded in a corpus (
 ## Checkpoints
 
 
-| # | Checkpoint | Proof |
-|---|-----------|-------|
-| CP1 | Command template + cross-artifact wiring + reference docs + render/bundle in one commit | `make render` and `make -C atomic bundle` leave a clean diff; help-router verification loop reports no `MISSING:` line for `/challenge-swarm` |
+| # | Checkpoint | Files/areas | Verifies |
+|---|-----------|-------------|----------|
+| CP1 | Command template + cross-artifact wiring + reference docs + render/bundle in one commit | `templates/commands/challenge-swarm.md` (+ rendered `commands/challenge-swarm.md`); cross-references in `templates/commands/atomic-plan.md`, `pressure-test.md`, `gather-evidence.md`, `atomic-help.md`; `CLAUDE.md`; `docs/reference/commands.md`, `docs/reference/workflow.md`; `docs/credits.md`; embedded bundle | `make render` and `make -C atomic bundle` leave a clean diff; help-router verification loop reports no `MISSING:` line for `/challenge-swarm` |
 
 
 ## Risks
@@ -126,3 +126,12 @@ atomic/internal/embedded/**             M  bundle regen (make -C atomic bundle)
 **What changed:** New command `/challenge-swarm` — multi-lens design challenger with isolated parallel subagents and a contradiction-map report, wired as the post-design gate across `/atomic-plan`, `/pressure-test`, `/gather-evidence`, `/atomic-help`, `CLAUDE.md`, and the reference docs.
 
 **Why:** The lifecycle had single-voice challenge gates only (`/pressure-test` dialogue, `atomic-reviewer` spec-mode alignment, `atomic-strategist` single heavyweight opinion). Nothing attacked a written design from multiple independent perspectives, and nothing surfaced the *disagreements between* perspectives — the highest-value signal for the trade-off decisions a design still owes.
+
+
+### 2026-07-05 — Correction: Checkpoints table columns
+
+**What changed:** The Checkpoints table used `# | Checkpoint | Proof`; reshaped to the required `# | Checkpoint | Files/areas | Verifies` — `Proof` folded into `Verifies`, `Files/areas` populated from the checkpoint's actual wiring. The single checkpoint's scope is unchanged.
+
+**Why:** `atomic validate spec` rule S5 requires the `# | Checkpoint | Files/areas | … | Verifies` column contract as an exact ordered subsequence; the `Proof` shorthand failed the gate.
+
+**Correction:** Found by `atomic validate spec` reporting S5 FAIL at the Checkpoints table.

--- a/docs/spec/cli-cobra.md
+++ b/docs/spec/cli-cobra.md
@@ -48,7 +48,7 @@ Top-level-only (no subcommands): the remaining 5 of the 17 (e.g. `doctor`, `upda
 
 ## Checkpoints
 
-| # | Checkpoint | Files / areas | Agent | Est. files | Verifies |
+| # | Checkpoint | Files/areas | Agent | Est. files | Verifies |
 |---|------------|---------------|-------|-----------|----------|
 | 0 | Add cobra dependency | `atomic/go.mod`, `atomic/go.sum` — `go get github.com/spf13/cobra@latest`; `go mod tidy` | implementer | 2 | `go build ./...` resolves cobra |
 | 1 | Cobra root + top-level verbs | `atomic/cmd/atomic/main.go` — replace the top-level switch and `fs.Usage` block with a Cobra root command + one `*cobra.Command` stub per current top-level verb (17: signals, reminder, hooks, claude, doctor, docker, update, config, followups, validate, docs, profile, code, wiki, prompt, serve, migrate); wire `--repo`, `--version`, `--no-update-check` as persistent/global flags; keep `runXxx` call-throughs identical | implementer | 1 | `atomic --help` shows all 17 verbs; `go test ./...` green |

--- a/docs/spec/serve-live-reload.md
+++ b/docs/spec/serve-live-reload.md
@@ -212,6 +212,5 @@ Built across 8 iterations of /subagent-implementation on branch `serve-live-relo
 - CP-5 → polish: a stale aborted mount could clear the shared in-flight flag under a newer mount — all shared-state writes are now gated on mount ownership (`systemMountAbort === abortController`).
 
 **Deferred items still open:**
-- FOLLOWUPS F-5 (🔵): `isNilGraphProvider` assumes pointer implementors (documented assumption; recommend drop unless a value-type provider ever appears).
 - Browser-visual manual gate: scroll-preserve paint, connectivity-dot transitions, and Cytoscape patch visuals verified by static trace + server-level curl only; eyeball pass pending (`atomic serve` + edit files).
 - Pre-existing `atomic validate spec` S5 failures on three unrelated specs (`atomic-migrate-framework`, `challenge-swarm`, `cli-cobra`) — present on `next` before this branch.

--- a/docs/spec/serve-live-reload.md
+++ b/docs/spec/serve-live-reload.md
@@ -188,3 +188,30 @@ atomic/internal/serve/
 | SSE-triggered scroll-preserve bypass interacts with the existing unconditional `htmx:after:swap` scroll reset used by ordinary navigation | Low | Bypass is scoped to swaps carrying the `live-swap` marker only; ordinary htmx navigation keeps today's reset behavior |
 
 ## Change log
+
+## Implementation log
+
+### shipped — 2026-07-05
+
+Built across 8 iterations of /subagent-implementation on branch `serve-live-reload` (worktree). Commits (chronological):
+
+- `88d7106` — CP-1 snapshot store (fp + nav + link graph, atomic swap, generation-keyed funnel)
+- `fdc5da4` — CP-2 handler migration (nav/page/rail/graph-data on the store; frozen singleton retired; `?live=1` staleness skip)
+- `f94e7b7` — CP-3 `/events` SSE + subscriber-gated ticker (coalescing slots, write deadlines, fast shutdown)
+- `c71f107` — CP-4 client page-mode reconcile (EventSource boot, fp seed, `HX-Live-Swap` per-request marker, connectivity dot)
+- `5c6dbc3` — CP-5 system-graph incremental patch (id-diff, neighbor seeding, scoped cola, IndexedDB re-key + prune)
+- `78d75be` — polish: typed-nil graphProvider degrade (page + rail), abortable mount with ownership-gated shared-state writes
+
+**Out-of-scope work performed during this build:**
+- Rail handler typed-nil guard: same defect class as the page handler's F-3, surfaced during the polish pass and fixed for consistency.
+
+**Unforeseens — surprises that emerged during implementation:**
+- CP-2: cold store raced the warm goroutine to a nil-graph snapshot (CAS loser returned the placeholder) — fixed by eager warm in the exported constructor.
+- CP-4: unseeded `lastSeenFp` made the resync push trigger a spurious full refetch on every page load — first message now seeds only.
+- CP-4: a shared DOM-attribute scroll-bypass marker raced overlapping swaps — replaced with a per-request `HX-Live-Swap` header read from htmx's request context.
+- CP-5 → polish: a stale aborted mount could clear the shared in-flight flag under a newer mount — all shared-state writes are now gated on mount ownership (`systemMountAbort === abortController`).
+
+**Deferred items still open:**
+- FOLLOWUPS F-5 (🔵): `isNilGraphProvider` assumes pointer implementors (documented assumption; recommend drop unless a value-type provider ever appears).
+- Browser-visual manual gate: scroll-preserve paint, connectivity-dot transitions, and Cytoscape patch visuals verified by static trace + server-level curl only; eyeball pass pending (`atomic serve` + edit files).
+- Pre-existing `atomic validate spec` S5 failures on three unrelated specs (`atomic-migrate-framework`, `challenge-swarm`, `cli-cobra`) — present on `next` before this branch.


### PR DESCRIPTION
`atomic serve` now reflects filesystem changes in an open browser tab without a restart or manual refresh, with near-zero cost when no tab is watching.

## What this solves

The link graph was built once at startup and frozen, so a file created mid-session never appeared in the graph, backlinks, or wikilink resolution until restart. Nav and the fingerprint cache each walked the tree independently. This unifies them into one realm snapshot and adds a live-push path for open tabs — the motivating case being agents writing files while a tab is open.

## Approach

- One realm snapshot (fingerprint + nav paths + link graph) behind a single atomic pointer, rebuilt through one generation-keyed funnel. Handlers read the snapshot; the startup-frozen graph and the per-request nav walk are gone.
- A `/events` SSE endpoint and a 10s ticker that runs only while a tab is subscribed. On change it pushes `{fp, changed}`; the provenance DAG and full graph JSON stay lazy, off the tick path. Shutdown with a live subscriber exits cleanly.
- The client reconciles in place: page mode refetches only the changed page and preserves scroll; system mode patches the Cytoscape graph by id-diff, keeping viewport and existing node positions. A quiet window holds back in-flight writes; a connectivity indicator shows stream state.

Also folds in a small S5 fix for three pre-existing non-conforming `## Checkpoints` tables (`atomic-migrate-framework`, `cli-cobra`, `challenge-swarm`), surfaced by this feature's `atomic validate spec` finalize gate.

Design and contract: `docs/design/serve-live-reload.md`, `docs/spec/serve-live-reload.md`.

Client-side behavior (scroll preserve, graph patch visuals, connectivity dot) has no JS test rig; it was verified by static trace and server-level checks, with a browser eyeball pass left as the manual gate.