### PR TITLE
fix: pin challenge-swarm lens dispatches to sonnet

### DIFF
--- a/atomic/internal/embedded/bundle/commands/challenge-swarm.md
+++ b/atomic/internal/embedded/bundle/commands/challenge-swarm.md
@@ -83,7 +83,7 @@ Communication runs through a workspace, not through shared context:
 ```
 
 
-Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization, so a heavier model adds cost, not insight. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
+Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization; a heavier tier may add insight, but it definitely adds cost. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
 
 
 The dispatch prompt is deliberately just pointers — identical for every lens except two paths:

--- a/atomic/internal/embedded/bundle/commands/challenge-swarm.md
+++ b/atomic/internal/embedded/bundle/commands/challenge-swarm.md
@@ -83,7 +83,7 @@ Communication runs through a workspace, not through shared context:
 ```
 
 
-Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel. Sonnet-tier is sufficient — the role file carries the specialization; inherit the session model when a tier override is unavailable.
+Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization, so a heavier model adds cost, not insight. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
 
 
 The dispatch prompt is deliberately just pointers — identical for every lens except two paths:
@@ -221,7 +221,7 @@ Numbered offers, typed selection:
 ```
 
 
-On `5`, delete the workspace directory — scratchpad is throwaway working memory. On `1`/`2`, dispatch only the named lens (same pointer prompt) and rebuild the map. On `3`/`4`, act, then re-offer.
+On `5`, delete the workspace directory — scratchpad is throwaway working memory. On `1`/`2`, dispatch only the named lens (same pointer prompt, same `model: sonnet`) and rebuild the map. On `3`/`4`, act, then re-offer.
 
 </workflow>
 
@@ -236,6 +236,7 @@ On `5`, delete the workspace directory — scratchpad is throwaway working memor
 4. **Filler dies at aggregation.** Dedupe, drop no-stake findings, keep the report shorter than the design.
 5. **Verify before asserting.** Contested checkable claims get resolved with tool calls before they appear in the map (same rule as `<investigate_before_answering>` in `CLAUDE.md`).
 6. **The roster is judgment, not a checklist.** 4-6 lenses that fit the change beat 7 that pad it.
+7. **Sonnet, pinned.** Every lens dispatch passes `model: sonnet`. Only an explicit user request for a different tier overrides it — never the session model.
 
 
 ## What this command does not do

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -24,7 +24,7 @@ func Manifest() []Artifact {
 		{Kind: "command", Source: "bundle/commands/atomic-help.md", Target: "commands/atomic-help.md", SHA256: "c8a58dd1d7ed0f4c178d5072dc59fbfe81107a367742151ff67bca72a58b6b6c"},
 		{Kind: "command", Source: "bundle/commands/atomic-plan.md", Target: "commands/atomic-plan.md", SHA256: "fc0a870e312ddf0271ad29754c1939786aa4121edbc2a9061c15872c40941dbb"},
 		{Kind: "command", Source: "bundle/commands/autopilot.md", Target: "commands/autopilot.md", SHA256: "c48159d297467cdedc9f59a563f71077480c397b60d5e82c971e49a12589f3f3"},
-		{Kind: "command", Source: "bundle/commands/challenge-swarm.md", Target: "commands/challenge-swarm.md", SHA256: "15edf7411816ab5c9e01d8cfd43d0d547ff8b3fbd7169e409c987b23311d5e39"},
+		{Kind: "command", Source: "bundle/commands/challenge-swarm.md", Target: "commands/challenge-swarm.md", SHA256: "b3a28f51690793c8f281677245a964010494b3b0042520ff679d426eae8cde4f"},
 		{Kind: "command", Source: "bundle/commands/commit.md", Target: "commands/commit.md", SHA256: "4a7321f58b12ea86e55d1732115f0462e32a813fa651146554cd1fd09e439e55"},
 		{Kind: "command", Source: "bundle/commands/documentation.md", Target: "commands/documentation.md", SHA256: "bba407a607927fccac6ede2f5364e8a0e750bed6bdf494b72c562018ea895c8a"},
 		{Kind: "command", Source: "bundle/commands/follow-up.md", Target: "commands/follow-up.md", SHA256: "a79e6a609297aa83d782da5ca7f1338f3d95b0ce0ee74f540889fc6f2f5b2490"},

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -24,7 +24,7 @@ func Manifest() []Artifact {
 		{Kind: "command", Source: "bundle/commands/atomic-help.md", Target: "commands/atomic-help.md", SHA256: "c8a58dd1d7ed0f4c178d5072dc59fbfe81107a367742151ff67bca72a58b6b6c"},
 		{Kind: "command", Source: "bundle/commands/atomic-plan.md", Target: "commands/atomic-plan.md", SHA256: "fc0a870e312ddf0271ad29754c1939786aa4121edbc2a9061c15872c40941dbb"},
 		{Kind: "command", Source: "bundle/commands/autopilot.md", Target: "commands/autopilot.md", SHA256: "c48159d297467cdedc9f59a563f71077480c397b60d5e82c971e49a12589f3f3"},
-		{Kind: "command", Source: "bundle/commands/challenge-swarm.md", Target: "commands/challenge-swarm.md", SHA256: "b3a28f51690793c8f281677245a964010494b3b0042520ff679d426eae8cde4f"},
+		{Kind: "command", Source: "bundle/commands/challenge-swarm.md", Target: "commands/challenge-swarm.md", SHA256: "be8a134582d0557fddbc088f82da43b48a613ea551e1f9b0908821b7cf8af4a9"},
 		{Kind: "command", Source: "bundle/commands/commit.md", Target: "commands/commit.md", SHA256: "4a7321f58b12ea86e55d1732115f0462e32a813fa651146554cd1fd09e439e55"},
 		{Kind: "command", Source: "bundle/commands/documentation.md", Target: "commands/documentation.md", SHA256: "bba407a607927fccac6ede2f5364e8a0e750bed6bdf494b72c562018ea895c8a"},
 		{Kind: "command", Source: "bundle/commands/follow-up.md", Target: "commands/follow-up.md", SHA256: "a79e6a609297aa83d782da5ca7f1338f3d95b0ce0ee74f540889fc6f2f5b2490"},

--- a/commands/challenge-swarm.md
+++ b/commands/challenge-swarm.md
@@ -83,7 +83,7 @@ Communication runs through a workspace, not through shared context:
 ```
 
 
-Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization, so a heavier model adds cost, not insight. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
+Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization; a heavier tier may add insight, but it definitely adds cost. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
 
 
 The dispatch prompt is deliberately just pointers — identical for every lens except two paths:

--- a/commands/challenge-swarm.md
+++ b/commands/challenge-swarm.md
@@ -83,7 +83,7 @@ Communication runs through a workspace, not through shared context:
 ```
 
 
-Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel. Sonnet-tier is sufficient — the role file carries the specialization; inherit the session model when a tier override is unavailable.
+Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization, so a heavier model adds cost, not insight. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
 
 
 The dispatch prompt is deliberately just pointers — identical for every lens except two paths:
@@ -221,7 +221,7 @@ Numbered offers, typed selection:
 ```
 
 
-On `5`, delete the workspace directory — scratchpad is throwaway working memory. On `1`/`2`, dispatch only the named lens (same pointer prompt) and rebuild the map. On `3`/`4`, act, then re-offer.
+On `5`, delete the workspace directory — scratchpad is throwaway working memory. On `1`/`2`, dispatch only the named lens (same pointer prompt, same `model: sonnet`) and rebuild the map. On `3`/`4`, act, then re-offer.
 
 </workflow>
 
@@ -236,6 +236,7 @@ On `5`, delete the workspace directory — scratchpad is throwaway working memor
 4. **Filler dies at aggregation.** Dedupe, drop no-stake findings, keep the report shorter than the design.
 5. **Verify before asserting.** Contested checkable claims get resolved with tool calls before they appear in the map (same rule as `<investigate_before_answering>` in `CLAUDE.md`).
 6. **The roster is judgment, not a checklist.** 4-6 lenses that fit the change beat 7 that pad it.
+7. **Sonnet, pinned.** Every lens dispatch passes `model: sonnet`. Only an explicit user request for a different tier overrides it — never the session model.
 
 
 ## What this command does not do

--- a/docs/spec/challenge-swarm.md
+++ b/docs/spec/challenge-swarm.md
@@ -10,7 +10,7 @@ One explicit command that subjects a written design, spec, or plan to 4-6 isolat
 ## Approach
 
 
-Adapted from Stanford's STORM: perspective-diverse agents grounded in a corpus (here, the codebase), kept isolated so that their independent agreements and disagreements are both informative. Role files carry the specialization, so lens agents run on a mid-tier model.
+Adapted from Stanford's STORM: perspective-diverse agents grounded in a corpus (here, the codebase), kept isolated so that their independent agreements and disagreements are both informative. Role files carry the specialization, so every lens dispatch pins `model: sonnet`; only an explicit user request for a different tier this run overrides the pin — the session model is never inherited by omission.
 
 
 ## Non-goals
@@ -29,7 +29,7 @@ Adapted from Stanford's STORM: perspective-diverse agents grounded in a corpus (
 
 - `/challenge-swarm @<path.md>` reads the target, orients in the code it touches, selects 4-6 fitting lenses, and prints the roster with a one-line reason per lens before dispatch.
 - Workspace created at `.claude/.scratchpad/<yyyy-mm-dd>-challenge-swarm-<slug>/` containing `lens-instructions.md` (verbatim from the command's canonical block), one `lenses/<lens>.md` role file per selected lens, and a `findings/` directory.
-- All lens subagents dispatched in a single message (parallel); the dispatch prompt is pointer-only and identical across lenses except the role-file path and findings path.
+- All lens subagents dispatched in a single message (parallel); the dispatch prompt is pointer-only and identical across lenses except the role-file path and findings path; every dispatch — including close-out lens reruns — passes `model: sonnet` unless the user explicitly requested a different tier this run.
 - No findings file is read until every lens has reported its one-line reply.
 - Report carries six sections in order: Verdict, Conflicts, Reinforced findings, Single-lens findings, Unexamined assumptions, Missing lens. Findings are severity-ordered and each carries evidence.
 - Contested claims that are objectively checkable are resolved by tool call (`atomic code` verbs, `sg`/grep, or a `tmp/` probe) before appearing in the map.
@@ -52,7 +52,7 @@ Adapted from Stanford's STORM: perspective-diverse agents grounded in a corpus (
 | Risk | Likelihood | Mitigation |
 |------|-----------|------------|
 | Lenses converge despite isolation (shared project instructions load into every subagent) | low | Role files dominate the lens's attention; behavioral rule forbids passing any lens's findings into another lens's prompt or role file |
-| Cost surprise — 4-6 subagents per run | low | Explicit-only invocation; roster printed before dispatch; lens agents run mid-tier |
+| Cost surprise — 4-6 subagents per run | low | Explicit-only invocation; roster printed before dispatch; every lens dispatch pins `model: sonnet` |
 | Findings filler buries real signal | medium | Lens instructions cap findings at 3-7 with mandatory evidence; aggregation cuts evidence-free and no-stake findings; report must stay shorter than the design |
 | Aggregator resolves conflicts it should surface | medium | Behavioral rule: surface the trade-off decision unless one side's evidence is decisively stronger |
 
@@ -135,3 +135,12 @@ atomic/internal/embedded/**             M  bundle regen (make -C atomic bundle)
 **Why:** `atomic validate spec` rule S5 requires the `# | Checkpoint | Files/areas | … | Verifies` column contract as an exact ordered subsequence; the `Proof` shorthand failed the gate.
 
 **Correction:** Found by `atomic validate spec` reporting S5 FAIL at the Checkpoints table.
+
+
+### 2026-07-10 — Lens dispatches pin `model: sonnet`
+
+**What changed:** Every lens dispatch (including close-out lens reruns) passes `model: sonnet`; only an explicit user request for a different tier this run overrides the pin. Approach, Success criteria, and the cost-surprise risk mitigation now state the pin; the command's Step 2, close-out, and behavioral rule 7 enforce it.
+
+**Why:** Issue #141 — the command's "mid-tier is sufficient" wording was a soft hint with a fall-through to the session model, so on a premium session (Opus, Fable) all 4-6 parallel lenses ran on the expensive session model.
+
+**Superseded:** Prior contract said lens agents "run on a mid-tier model" without a mechanism; the command allowed inheriting the session model when a tier override was unavailable.

--- a/templates/commands/challenge-swarm.md
+++ b/templates/commands/challenge-swarm.md
@@ -83,7 +83,7 @@ Communication runs through a workspace, not through shared context:
 ```
 
 
-Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization, so a heavier model adds cost, not insight. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
+Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization; a heavier tier may add insight, but it definitely adds cost. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
 
 
 The dispatch prompt is deliberately just pointers — identical for every lens except two paths:

--- a/templates/commands/challenge-swarm.md
+++ b/templates/commands/challenge-swarm.md
@@ -83,7 +83,7 @@ Communication runs through a workspace, not through shared context:
 ```
 
 
-Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel. Sonnet-tier is sufficient — the role file carries the specialization; inherit the session model when a tier override is unavailable.
+Write `lens-instructions.md` verbatim from the block below, then one role file per lens. Dispatch **one `general-purpose` subagent per lens, all in a single message** so they run in parallel, and pass **`model: sonnet` on every dispatch** — the role file carries the specialization, so a heavier model adds cost, not insight. Use a different tier only when the user explicitly asks for one this run; never inherit the session model by omission — on a premium session tier (Opus, Fable) an unpinned dispatch multiplies spend across 4-6 agents.
 
 
 The dispatch prompt is deliberately just pointers — identical for every lens except two paths:
@@ -221,7 +221,7 @@ Numbered offers, typed selection:
 ```
 
 
-On `5`, delete the workspace directory — scratchpad is throwaway working memory. On `1`/`2`, dispatch only the named lens (same pointer prompt) and rebuild the map. On `3`/`4`, act, then re-offer.
+On `5`, delete the workspace directory — scratchpad is throwaway working memory. On `1`/`2`, dispatch only the named lens (same pointer prompt, same `model: sonnet`) and rebuild the map. On `3`/`4`, act, then re-offer.
 
 </workflow>
 
@@ -236,6 +236,7 @@ On `5`, delete the workspace directory — scratchpad is throwaway working memor
 4. **Filler dies at aggregation.** Dedupe, drop no-stake findings, keep the report shorter than the design.
 5. **Verify before asserting.** Contested checkable claims get resolved with tool calls before they appear in the map (same rule as `<investigate_before_answering>` in `CLAUDE.md`).
 6. **The roster is judgment, not a checklist.** 4-6 lenses that fit the change beat 7 that pad it.
+7. **Sonnet, pinned.** Every lens dispatch passes `model: sonnet`. Only an explicit user request for a different tier overrides it — never the session model.
 
 
 ## What this command does not do


### PR DESCRIPTION
Closes #141.

/challenge-swarm's Step 2 carried only a soft mid-tier hint with a fall-through to the session model, so on a premium session (Opus, Fable) all 4-6 parallel lenses ran on the expensive session model. Every lens dispatch — including close-out reruns — now passes `model: sonnet`; only an explicit user request for a different tier this run overrides it. Behavioral rule 7 backs the pin at the constraint level, and `docs/spec/challenge-swarm.md` now states it in Approach, Success criteria, and the cost-surprise risk mitigation, with a change-log entry.