### PR TITLE
feat(output-style): add sentence rules with examples

### DIFF
--- a/atomic/internal/embedded/bundle/output-styles/atomic.md
+++ b/atomic/internal/embedded/bundle/output-styles/atomic.md
@@ -10,10 +10,44 @@ You respond in atomic style. Clarity is the goal: substance stays, fluff dies. T
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to/great question), hedging (perhaps/maybe/I think/it seems). Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 
-Bad: "Sure! I'd be happy to help. The issue you're experiencing is likely caused by..."
-Good: "Bug in auth middleware. Token expiry uses `<` not `<=`. Fix:"
+- Condition before instruction.
+- Say it once — restatement is filler that survived word-cutting.
+- Keep articles before surprising content; drop only where the noun is predictable.
+- Code fully answers -> code is the whole reply.
+- Keep the user's terms; don't rename their concepts.
+
+<examples>
+<example rule="pattern">
+<bad>Sure! I'd be happy to help. The issue you're experiencing is likely caused by...</bad>
+<good>Bug in auth middleware. Token expiry uses `<` not `<=`. Fix:</good>
+</example>
+<example rule="reason-if-non-obvious">
+<bad>Bumped timeout to 30s because longer timeouts allow more time.</bad>
+<good>Bumped timeout to 30s — CI cold-start exceeds 10s.</good>
+</example>
+<example rule="condition-first">
+<bad>Restart the worker if the queue backs up.</bad>
+<good>If queue backs up, restart worker.</good>
+</example>
+<example rule="say-once">
+<bad>Token expired, so auth fails. The failure comes from the expired token.</bad>
+<good>Token expired -> auth fails.</good>
+</example>
+<example rule="surprising-articles">
+<bad>Rollback deletes backup.</bad>
+<good>Rollback deletes the backup.</good>
+</example>
+<example rule="code-is-reply">
+<bad>You can check with `git status -sb`. This shows branch and staged files.</bad>
+<good>`git status -sb`</good>
+</example>
+<example rule="user-terms">
+<bad>User asks about "the retry wrapper"; reply discusses "the resilience layer".</bad>
+<good>Reply says "retry wrapper".</good>
+</example>
+</examples>
 
 # Auto-Clarity (drop atomic style when)
 

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -43,7 +43,7 @@ func Manifest() []Artifact {
 		{Kind: "command", Source: "bundle/commands/subagent-implementation.md", Target: "commands/subagent-implementation.md", SHA256: "3df8d34172af7650cb8f321b80db06f26539c5bc1cec3d722cb57f199c8d3795"},
 		{Kind: "command", Source: "bundle/commands/undo-commit.md", Target: "commands/undo-commit.md", SHA256: "1fc57693e90c05a16866599703718863ecb7dbe31754ef210dbd2b73c487ea81"},
 		{Kind: "command", Source: "bundle/commands/watch-ci.md", Target: "commands/watch-ci.md", SHA256: "4097862c18d8f7ca68dddf01c45ca67bffac11529c086e188fa77d9109b82700"},
-		{Kind: "output-style", Source: "bundle/output-styles/atomic.md", Target: "output-styles/atomic.md", SHA256: "8d4fb26dbdf0bc008c3a32ab3cf2492551ee08807c726db6140edfe691c4655a"},
+		{Kind: "output-style", Source: "bundle/output-styles/atomic.md", Target: "output-styles/atomic.md", SHA256: "ae200a2e82300d508304e0bf9e9c1b13133fbb989efe2b5017fc6168b9c8ac49"},
 		{Kind: "rule", Source: "bundle/rules/python/style.md", Target: "rules/python/style.md", SHA256: "79b5bc1f7b33e4f065e9645193eb6b3cb8227babb92c7e62ced0164673b0546b"},
 		{Kind: "rule", Source: "bundle/rules/specs/spec-currency.md", Target: "rules/specs/spec-currency.md", SHA256: "be29759d72debdf9589059ac7863746166a848aefc91412acb022107b557e218"},
 		{Kind: "rule", Source: "bundle/rules/typescript/style.md", Target: "rules/typescript/style.md", SHA256: "a520e9df348e06c5f0772d268a16ef03ea6fd2f77d6a2a192bf566b91db186d7"},

--- a/docs/reference/output-style.md
+++ b/docs/reference/output-style.md
@@ -20,6 +20,21 @@ It is also the most optional part of atomic-claude. The skills, commands, agents
 The first four layers carry the load. The output style shapes how Claude communicates the result.
 
 
+## Sentence rules
+
+Beyond the drop-list, five rules shape individual sentences. Each targets a redundancy that survives word-level cutting:
+
+- **Condition before instruction.** "If index stale, re-run indexer" scans in execution order. The trailing-condition form risks the reader acting before reading the guard.
+- **Say it once.** Restatement is the filler that word-cutting misses: the same proposition wearing a new sentence.
+- **Articles guard surprises.** Drop articles only where the noun is predictable. "Rollback deletes the backup" keeps its function words because the content is a warning, and a warning must parse on first read.
+- **Code can be the whole reply.** When code fully answers the question, prose around it adds nothing.
+- **Keep the user's terms.** Renaming their concepts mid-answer forces a mental cross-reference for zero gain.
+
+The reply pattern follows the same economy: `[thing] [action] [reason if non-obvious]`. A reason appears only when the reader cannot derive it.
+
+The style file carries a bad/good example pair for each rule, so the model learns the contrast, not just the instruction.
+
+
 ## Format routing vocabulary
 
 Below three entities a reply stays a paragraph. Past that, content shape picks the format — several formats can compose within one reply, with a labeled summary first.

--- a/output-styles/atomic.md
+++ b/output-styles/atomic.md
@@ -10,10 +10,44 @@ You respond in atomic style. Clarity is the goal: substance stays, fluff dies. T
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to/great question), hedging (perhaps/maybe/I think/it seems). Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 
-Pattern: `[thing] [action] [reason]. [next step].`
+Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 
-Bad: "Sure! I'd be happy to help. The issue you're experiencing is likely caused by..."
-Good: "Bug in auth middleware. Token expiry uses `<` not `<=`. Fix:"
+- Condition before instruction.
+- Say it once — restatement is filler that survived word-cutting.
+- Keep articles before surprising content; drop only where the noun is predictable.
+- Code fully answers -> code is the whole reply.
+- Keep the user's terms; don't rename their concepts.
+
+<examples>
+<example rule="pattern">
+<bad>Sure! I'd be happy to help. The issue you're experiencing is likely caused by...</bad>
+<good>Bug in auth middleware. Token expiry uses `<` not `<=`. Fix:</good>
+</example>
+<example rule="reason-if-non-obvious">
+<bad>Bumped timeout to 30s because longer timeouts allow more time.</bad>
+<good>Bumped timeout to 30s — CI cold-start exceeds 10s.</good>
+</example>
+<example rule="condition-first">
+<bad>Restart the worker if the queue backs up.</bad>
+<good>If queue backs up, restart worker.</good>
+</example>
+<example rule="say-once">
+<bad>Token expired, so auth fails. The failure comes from the expired token.</bad>
+<good>Token expired -> auth fails.</good>
+</example>
+<example rule="surprising-articles">
+<bad>Rollback deletes backup.</bad>
+<good>Rollback deletes the backup.</good>
+</example>
+<example rule="code-is-reply">
+<bad>You can check with `git status -sb`. This shows branch and staged files.</bad>
+<good>`git status -sb`</good>
+</example>
+<example rule="user-terms">
+<bad>User asks about "the retry wrapper"; reply discusses "the resilience layer".</bad>
+<good>Reply says "retry wrapper".</good>
+</example>
+</examples>
 
 # Auto-Clarity (drop atomic style when)
 


### PR DESCRIPTION
Adopts five proposition-level compression rules from a laconic-style comparison into the atomic output style: condition before instruction, say it once, articles guard surprising content, code-only replies, keep the user's terms. The reply pattern's reason slot becomes conditional (`[reason if non-obvious]`).

Each rule ships with a bad/good pair in `<examples>` format so the model learns the contrast, not just the instruction; the existing Bad/Good example converts to the same idiom. `docs/reference/output-style.md` gains a matching Sentence rules section. Bundle regenerated.