### PR TITLE
fix(yagni): codebase reuse outranks builtins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,10 @@ Personal facts about you — name, role, employer, active projects, interests, p
 
 - **Simplicity first (YAGNI).** Walk this ladder before writing anything; stop at the first hit:
   1. Does it need to exist at all? No → skip it.
-  2. Does the stdlib do it? → use the stdlib.
-  3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-  4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-  5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+  2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+  3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+  4. Does the stdlib do it? → use the stdlib.
+  5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
   6. Can it be one line? → write the one line.
   7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/agents/atomic-implementer.md
+++ b/agents/atomic-implementer.md
@@ -65,10 +65,10 @@ No apologies, no alternatives. Bounce and stop.
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/agents/atomic-reviewer.md
+++ b/agents/atomic-reviewer.md
@@ -52,10 +52,10 @@ Place suppression-pattern findings in the **Code quality** subsection.
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/agents/atomic-strategist.md
+++ b/agents/atomic-strategist.md
@@ -57,10 +57,10 @@ When evaluating approaches, consider:
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/atomic/internal/embedded/bundle/CLAUDE.md
+++ b/atomic/internal/embedded/bundle/CLAUDE.md
@@ -21,10 +21,10 @@ Personal facts about you — name, role, employer, active projects, interests, p
 
 - **Simplicity first (YAGNI).** Walk this ladder before writing anything; stop at the first hit:
   1. Does it need to exist at all? No → skip it.
-  2. Does the stdlib do it? → use the stdlib.
-  3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-  4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-  5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+  2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+  3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+  4. Does the stdlib do it? → use the stdlib.
+  5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
   6. Can it be one line? → write the one line.
   7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/atomic/internal/embedded/bundle/agents/atomic-implementer.md
+++ b/atomic/internal/embedded/bundle/agents/atomic-implementer.md
@@ -65,10 +65,10 @@ No apologies, no alternatives. Bounce and stop.
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/atomic/internal/embedded/bundle/agents/atomic-reviewer.md
+++ b/atomic/internal/embedded/bundle/agents/atomic-reviewer.md
@@ -52,10 +52,10 @@ Place suppression-pattern findings in the **Code quality** subsection.
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/atomic/internal/embedded/bundle/agents/atomic-strategist.md
+++ b/atomic/internal/embedded/bundle/agents/atomic-strategist.md
@@ -57,10 +57,10 @@ When evaluating approaches, consider:
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -13,12 +13,12 @@ type Artifact struct {
 // Generated at build time by cmd/bundle-mirror; commit the result.
 func Manifest() []Artifact {
 	return []Artifact{
-		{Kind: "agent", Source: "bundle/agents/atomic-implementer.md", Target: "agents/atomic-implementer.md", SHA256: "4a06f515fe02a613b99513430ee97b42f11332c3940e9123a6ebec8b366dfbd0"},
+		{Kind: "agent", Source: "bundle/agents/atomic-implementer.md", Target: "agents/atomic-implementer.md", SHA256: "3f8d70ef8e882bb2dc42484d71c60dcf69b7cff4fe08df033048d6624eed1ace"},
 		{Kind: "agent", Source: "bundle/agents/atomic-investigator.md", Target: "agents/atomic-investigator.md", SHA256: "52572452c80162c61a8b1fe50f47cc37810965a2b62f417da951ecf575e9aeef"},
-		{Kind: "agent", Source: "bundle/agents/atomic-reviewer.md", Target: "agents/atomic-reviewer.md", SHA256: "1c5000277c9f20f15fff154e365380acb8ab0d518955a6077c77f24e487ba8bf"},
-		{Kind: "agent", Source: "bundle/agents/atomic-strategist.md", Target: "agents/atomic-strategist.md", SHA256: "2d002229a7a7ae6f865c550c7aa941f9a01e8572e3610379d12ff5fe015bf162"},
+		{Kind: "agent", Source: "bundle/agents/atomic-reviewer.md", Target: "agents/atomic-reviewer.md", SHA256: "1397606f2a36940bf81d5d5f4688cd15b6ad3b8bb105e1b72415810ac40312de"},
+		{Kind: "agent", Source: "bundle/agents/atomic-strategist.md", Target: "agents/atomic-strategist.md", SHA256: "fce077f4e17942ea4129a77915de631394f7eae281353172abfff9b2ae95aadd"},
 		{Kind: "agent", Source: "bundle/agents/atomic-wiki-inferrer.md", Target: "agents/atomic-wiki-inferrer.md", SHA256: "5467ef4d2f64e512a632c038f91f1bdf389f9ce06293c869f45bb0b7541c9f29"},
-		{Kind: "claude-md", Source: "bundle/CLAUDE.md", Target: "CLAUDE.md", SHA256: "3770ccdcff3c3d4069d8d862a9191ebff6fb638095011067551ad89d88e5ca4a"},
+		{Kind: "claude-md", Source: "bundle/CLAUDE.md", Target: "CLAUDE.md", SHA256: "8178553a082fbf6d36333cb9a81864dc454c239cd302ae788cca90355beb846f"},
 		{Kind: "command", Source: "bundle/commands/_templates/implementer-prompt.md", Target: "commands/_templates/implementer-prompt.md", SHA256: "88821c30f61b773218b90332f2060eec09979515545aaddfcb10081f1e8ce14f"},
 		{Kind: "command", Source: "bundle/commands/_templates/reviewer-prompt.md", Target: "commands/_templates/reviewer-prompt.md", SHA256: "296889105ed096f4afb9239c5931f9b900037d55e676f89bf3023daf5d62ffed"},
 		{Kind: "command", Source: "bundle/commands/atomic-help.md", Target: "commands/atomic-help.md", SHA256: "c8a58dd1d7ed0f4c178d5072dc59fbfe81107a367742151ff67bca72a58b6b6c"},

--- a/templates/shared/agent-yagni.md
+++ b/templates/shared/agent-yagni.md
@@ -4,10 +4,10 @@
 Walk this ladder before writing anything; stop at the first hit:
 
 1. Does it need to exist at all? No → skip it.
-2. Does the stdlib do it? → use the stdlib.
-3. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
-4. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
-5. Does something in the codebase already solve it? → reuse it; don't rewrite.
+2. Does something in the codebase already solve it? → reuse it; don't rewrite.
+3. Does an already-installed dependency solve it? → use it; don't add a new dep when a few lines do.
+4. Does the stdlib do it? → use the stdlib.
+5. Does a native platform feature cover it? → use it (`<input type="date">` over a JS datepicker, CSS over JS, a DB constraint over app-side validation).
 6. Can it be one line? → write the one line.
 7. Otherwise → write the **minimum** code that fully solves the problem.
 


### PR DESCRIPTION
Reorders YAGNI ladder steps 2-5 to: codebase reuse, installed deps, stdlib, native platform. Agents walked the old order top-down and built with builtins instead of reusing the patterns and libraries the codebase already established. Synced verbatim across CLAUDE.md and the agent-yagni partial; agents re-rendered, bundle regenerated.