### PR TITLE
fix(wiki): drop concrete names from steering scaffold examples

### DIFF
--- a/atomic/internal/wiki/init.go
+++ b/atomic/internal/wiki/init.go
@@ -6,11 +6,12 @@ import (
 )
 
 // repoSteeringScaffold is the fixed-content docs/wiki/CLAUDE.md scaffold for
-// repo scope. The section examples live inside HTML comments so neither
-// markdown rendering nor the inferrer can mistake them for real steering —
-// the previous scaffold shipped its examples as live markdown ("# NestJS
-// monorepo" parsed as a heading, not a comment) and inferrer runs had to
-// detect and ignore fabricated facts on every uncustomized repo.
+// repo scope. Two constraints shape the examples: they live inside HTML
+// comments so markdown rendering can't promote them to headings, and they
+// name no concrete framework, tool, or path — the file loads verbatim into
+// model context as nested memory, so even a commented concrete name (an
+// earlier scaffold said "NestJS monorepo") reads as a fact about the repo
+// and derails inferrer runs on every uncustomized checkout.
 const repoSteeringScaffold = `---
 type: Steering
 description: Authoritative steering for the signals/wiki inferrer when operating under docs/wiki/.
@@ -25,27 +26,27 @@ description: Authoritative steering for the signals/wiki inferrer when operating
 
 ## Framework
 
-<!-- example: NestJS monorepo (not plain Express) -->
+<!-- example: <the real framework> (not <what detection wrongly guessed>) -->
 
 ## Domains
 
 <!-- example:
-- src/billing/ and src/payments/ are one domain ("payments")
-- src/internal-tools/ is scratch code — not a real domain
+- <dir-a>/ and <dir-b>/ are one domain ("<domain-name>")
+- <dir-c>/ is scratch code — not a real domain
 -->
 
 ## Build
 
 <!-- example:
-- Build: pnpm turbo build
-- Test: pnpm test:ci (not pnpm test — that runs watch mode)
+- Build: <build command>
+- Test: <ci test command> (not <the watch-mode command>)
 -->
 
 ## Ignore for domains
 
 <!-- example:
-- vendor/
-- generated/
+- <vendored-dir>/
+- <generated-output-dir>/
 -->
 `
 

--- a/atomic/internal/wiki/init_test.go
+++ b/atomic/internal/wiki/init_test.go
@@ -12,9 +12,10 @@ import (
 // goldenRepoScaffold is an independently-copied fixture of the repo-scope
 // scaffold. Kept separate from repoSteeringScaffold in init.go so this test
 // catches accidental drift in the source constant, not just self-consistency
-// with it. Invariant the fixture encodes: every illustrative example lives
-// inside an HTML comment, so an uncustomized scaffold contains zero live
-// steering facts.
+// with it. Invariants the fixture encodes: every illustrative example lives
+// inside an HTML comment, and no example names a concrete framework, tool,
+// or path — an uncustomized scaffold contains zero repo facts a model could
+// pick up from context.
 const goldenRepoScaffold = `---
 type: Steering
 description: Authoritative steering for the signals/wiki inferrer when operating under docs/wiki/.
@@ -29,27 +30,27 @@ description: Authoritative steering for the signals/wiki inferrer when operating
 
 ## Framework
 
-<!-- example: NestJS monorepo (not plain Express) -->
+<!-- example: <the real framework> (not <what detection wrongly guessed>) -->
 
 ## Domains
 
 <!-- example:
-- src/billing/ and src/payments/ are one domain ("payments")
-- src/internal-tools/ is scratch code — not a real domain
+- <dir-a>/ and <dir-b>/ are one domain ("<domain-name>")
+- <dir-c>/ is scratch code — not a real domain
 -->
 
 ## Build
 
 <!-- example:
-- Build: pnpm turbo build
-- Test: pnpm test:ci (not pnpm test — that runs watch mode)
+- Build: <build command>
+- Test: <ci test command> (not <the watch-mode command>)
 -->
 
 ## Ignore for domains
 
 <!-- example:
-- vendor/
-- generated/
+- <vendored-dir>/
+- <generated-output-dir>/
 -->
 `
 


### PR DESCRIPTION
The docs/wiki/CLAUDE.md steering scaffold shipped illustrative examples naming a real framework ("NestJS monorepo (not plain Express)"), a real build tool ("pnpm turbo build"), and real paths ("src/billing/"). Moving them into HTML comments (the previous fix) wasn't enough: the steering file loads verbatim into model context as nested memory, so runs still pick up "NestJS" and treat it as a fact about the repo — every uncustomized checkout disorients the inferrer.

Replaces all example content with placeholder shapes (`<the real framework>`, `<build command>`), so the scaffold carries zero concrete repo facts. Existing generated steering files are untouched (the scaffold no-ops when the file exists); those need a one-time manual cleanup per repo.