### PR TITLE
fix(ci): install bun in test job and isolate frontend test state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Verify render is committed
         run: git diff --exit-code
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Install frontend dependencies
+        working-directory: ./atomic/internal/serve/frontend
+        run: bun install --frozen-lockfile
+
       - name: Generate bundle
         run: go generate ./...
 

--- a/atomic/cmd/atomic/main_test.go
+++ b/atomic/cmd/atomic/main_test.go
@@ -820,7 +820,10 @@ func TestRunProfile_UsesHomeNotClaudeHome(t *testing.T) {
 
 	home := t.TempDir()
 	cmd := exec.Command(os.Args[0], "-test.run=TestRunProfile_UsesHomeNotClaudeHome")
-	cmd.Env = append(os.Environ(), "ATOMIC_TEST_RUN_PROFILE_HELPER=1", "HOME="+home)
+	// PATH is stripped so the profile detectors find no real tools: the test
+	// guards home-path resolution only, and a real probe (e.g. bazel) writes
+	// its cache into the temp HOME and races t.TempDir cleanup on CI.
+	cmd.Env = append(os.Environ(), "ATOMIC_TEST_RUN_PROFILE_HELPER=1", "HOME="+home, "PATH=")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("subprocess runProfile failed: %v\n%s", err, out)
 	}

--- a/atomic/internal/serve/frontend/src/components/rail/MiniGraph.test.tsx
+++ b/atomic/internal/serve/frontend/src/components/rail/MiniGraph.test.tsx
@@ -63,6 +63,10 @@ describe("MiniGraph", () => {
     __resetForTest();
     __resetLoadScriptCacheForTest();
     delete (window as { cytoscape?: unknown }).cytoscape;
+    // registerRailCy (railCytoscapeStyle.ts) stashes the mounted Cytoscape
+    // instance on this same module-level global — leaking it here makes
+    // railCytoscapeStyle.test.ts's "nothing registered" case order-dependent.
+    delete window.__railCy;
     document.body.innerHTML = "";
   });
 

--- a/atomic/internal/serve/frontend/src/components/rail/Rail.test.tsx
+++ b/atomic/internal/serve/frontend/src/components/rail/Rail.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { ApiProvider } from "../../utils/api";
 import { events } from "../../utils/events";
+import { __resetLoadScriptCacheForTest } from "../../utils/loadScript";
 import { Rail } from "./Rail";
 import type { RailResponse } from "./types";
 
@@ -64,6 +65,12 @@ function mockFetchOnce(body: unknown, status = 200) {
 describe("Rail", () => {
   afterEach(() => {
     mock.restore();
+    // Rail mounts MiniGraph whenever a fixture carries graphDataURL, which
+    // drives the real (unstubbed here) loadScript("/vendor/cytoscape.min.js")
+    // path — happy-dom throws synchronously on the real script append, and
+    // that rejected promise stays cached at module scope unless cleared,
+    // short-circuiting any later file's stubbed load for the same src.
+    __resetLoadScriptCacheForTest();
   });
 
   test("renders nothing but the bare aside until page.resolved fires", () => {

--- a/atomic/internal/serve/frontend/src/components/rail/Rail.test.tsx
+++ b/atomic/internal/serve/frontend/src/components/rail/Rail.test.tsx
@@ -1,46 +1,32 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { ApiProvider } from "../../utils/api";
 import { events } from "../../utils/events";
-import { __resetLoadScriptCacheForTest } from "../../utils/loadScript";
+
+// Rail mounts MiniGraph whenever a fixture carries graphDataURL. The graph
+// subsystem itself (Cytoscape lazy-load, layout wiring, hover/click) is
+// covered in isolation by MiniGraph.test.tsx — this file only asserts the
+// Properties/OUT/IN panels and the clear-on-null behavior, so mocking
+// MiniGraph out here removes an entire async surface these tests never
+// needed exercised (script load + a FetchEngine graph-data request that
+// MiniGraph never passes an AbortController for, so it's still in flight
+// when a test unmounts it) with zero coverage loss.
+//
+// mock.module() is process-global once registered, and bun:test's own
+// mock.restore() does NOT undo it (verified: an afterAll(() => mock.restore())
+// here left the mock active for a later file). Capture the real module via
+// require() — evaluated exactly where it's written, unlike a hoisted static
+// import — before registering the mock, then re-register that real module
+// explicitly in afterAll so a later file (e.g. MiniGraph.test.tsx) importing
+// "./MiniGraph" directly still gets the genuine component.
+const RealMiniGraph: typeof import("./MiniGraph") = require("./MiniGraph");
+
+mock.module("./MiniGraph", () => ({
+  MiniGraph: () => null,
+}));
+
 import { Rail } from "./Rail";
 import type { RailResponse } from "./types";
-
-// Every RAIL_FIXTURE below carries a graphDataURL, so every test in this file
-// mounts MiniGraph, which lazy-loads the carried Cytoscape vendor script via
-// loadScript(). Left unstubbed, that hits happy-dom's real script-element
-// connect path (see loadScript.test.ts's stubScriptLoad comment) — locally
-// that rejects synchronously, but it's a browser-API implementation detail,
-// not a contract: on CI it was observed to not settle promptly, riding
-// "clears the rail"'s awaits to bun's 5s per-test timeout. Stubbing the
-// script element (and providing a minimal window.cytoscape so MiniGraph's
-// mount promise chain always resolves the same way) decouples this file's
-// assertions from that environment-dependent timing entirely.
-function stubScriptLoad() {
-  const origCreate = document.createElement.bind(document);
-  document.createElement = ((tag: string) => {
-    if (tag === "script") {
-      const el = origCreate("div") as unknown as HTMLScriptElement;
-      queueMicrotask(() => el.dispatchEvent(new Event("load")));
-      return el;
-    }
-    return origCreate(tag);
-  }) as typeof document.createElement;
-  return () => {
-    document.createElement = origCreate;
-  };
-}
-
-function stubCytoscape() {
-  return mock(() => ({
-    resize: () => {},
-    fit: () => {},
-    one: (_event: string, cb: () => void) => cb(),
-    ready: (cb: () => void) => cb(),
-    on: () => {},
-    style: () => {},
-  }));
-}
 
 const RAIL_FIXTURE: RailResponse = {
   relpath: "wiki/index.md",
@@ -98,30 +84,15 @@ function mockFetchOnce(body: unknown, status = 200) {
   ) as unknown as typeof fetch;
 }
 
-// Counts only /api/rail/* calls out of a fetch mock — MiniGraph's own
-// graphDataURL fetch shares the same globalThis.fetch and would otherwise
-// inflate a spy meant to track Rail's own refetch-on-realm.changed behavior.
-function railCallCount(fetchSpy: ReturnType<typeof mock>): number {
-  return fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-    (typeof input === "string" ? input : input.toString()).includes("/rail/"),
-  ).length;
-}
-
 describe("Rail", () => {
-  let restoreScriptLoad: () => void;
-
-  beforeEach(() => {
-    restoreScriptLoad = stubScriptLoad();
-    (window as unknown as { cytoscape: ReturnType<typeof stubCytoscape> }).cytoscape = stubCytoscape();
-  });
-
-  afterEach(() => {
-    mock.restore();
-    // Module-scope cache — reset so no test's script-load resolution leaks
-    // into a later file's own loadScript assertions.
-    __resetLoadScriptCacheForTest();
-    restoreScriptLoad();
-    delete (window as { cytoscape?: unknown }).cytoscape;
+  // Deliberately no per-test mock.restore(): every test reassigns
+  // globalThis.fetch fresh, so there's no cross-test mock-call-history to
+  // clean up. Restored once, for the whole file, in afterAll instead — so a
+  // later file (e.g. MiniGraph.test.tsx) still resolves the real
+  // "./MiniGraph" (mock.restore() alone does not undo mock.module(), so this
+  // re-registers the captured real module explicitly).
+  afterAll(() => {
+    mock.module("./MiniGraph", () => RealMiniGraph);
   });
 
   test("renders nothing but the bare aside until page.resolved fires", () => {
@@ -143,7 +114,9 @@ describe("Rail", () => {
       </ApiProvider>,
     );
 
-    events.emit("page.resolved", { relpath: "wiki/index.md" });
+    await act(async () => {
+      events.emit("page.resolved", { relpath: "wiki/index.md" });
+    });
 
     await waitFor(() => expect(document.querySelector("#rail-props")).not.toBeNull());
 
@@ -178,10 +151,14 @@ describe("Rail", () => {
       </ApiProvider>,
     );
 
-    events.emit("page.resolved", { relpath: "wiki/index.md" });
+    await act(async () => {
+      events.emit("page.resolved", { relpath: "wiki/index.md" });
+    });
     await waitFor(() => expect(document.querySelector("#rail-props")).not.toBeNull());
 
-    events.emit("page.resolved", { relpath: null });
+    await act(async () => {
+      events.emit("page.resolved", { relpath: null });
+    });
     await waitFor(() => expect(document.querySelector("#rail-props")).toBeNull());
   });
 
@@ -219,13 +196,13 @@ describe("Rail", () => {
 
     events.emit("page.resolved", { relpath: "wiki/index.md" });
     await waitFor(() => expect(document.querySelector("#rail-props")).not.toBeNull());
-    expect(railCallCount(fetchSpy)).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       events.emit("realm.changed", { fp: "fp2", changed: ["wiki/index.md"] });
     });
 
-    await waitFor(() => expect(railCallCount(fetchSpy)).toBe(2));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
   });
 
   test("does not refetch on realm.changed when the open relpath is absent from a bounded changed list", async () => {
@@ -246,13 +223,13 @@ describe("Rail", () => {
 
     events.emit("page.resolved", { relpath: "wiki/index.md" });
     await waitFor(() => expect(document.querySelector("#rail-props")).not.toBeNull());
-    expect(railCallCount(fetchSpy)).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       events.emit("realm.changed", { fp: "fp2", changed: ["some/other.md"] });
     });
 
     await new Promise((r) => setTimeout(r, 20));
-    expect(railCallCount(fetchSpy)).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/atomic/internal/serve/frontend/src/components/rail/Rail.test.tsx
+++ b/atomic/internal/serve/frontend/src/components/rail/Rail.test.tsx
@@ -1,10 +1,46 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { ApiProvider } from "../../utils/api";
 import { events } from "../../utils/events";
 import { __resetLoadScriptCacheForTest } from "../../utils/loadScript";
 import { Rail } from "./Rail";
 import type { RailResponse } from "./types";
+
+// Every RAIL_FIXTURE below carries a graphDataURL, so every test in this file
+// mounts MiniGraph, which lazy-loads the carried Cytoscape vendor script via
+// loadScript(). Left unstubbed, that hits happy-dom's real script-element
+// connect path (see loadScript.test.ts's stubScriptLoad comment) — locally
+// that rejects synchronously, but it's a browser-API implementation detail,
+// not a contract: on CI it was observed to not settle promptly, riding
+// "clears the rail"'s awaits to bun's 5s per-test timeout. Stubbing the
+// script element (and providing a minimal window.cytoscape so MiniGraph's
+// mount promise chain always resolves the same way) decouples this file's
+// assertions from that environment-dependent timing entirely.
+function stubScriptLoad() {
+  const origCreate = document.createElement.bind(document);
+  document.createElement = ((tag: string) => {
+    if (tag === "script") {
+      const el = origCreate("div") as unknown as HTMLScriptElement;
+      queueMicrotask(() => el.dispatchEvent(new Event("load")));
+      return el;
+    }
+    return origCreate(tag);
+  }) as typeof document.createElement;
+  return () => {
+    document.createElement = origCreate;
+  };
+}
+
+function stubCytoscape() {
+  return mock(() => ({
+    resize: () => {},
+    fit: () => {},
+    one: (_event: string, cb: () => void) => cb(),
+    ready: (cb: () => void) => cb(),
+    on: () => {},
+    style: () => {},
+  }));
+}
 
 const RAIL_FIXTURE: RailResponse = {
   relpath: "wiki/index.md",
@@ -62,15 +98,30 @@ function mockFetchOnce(body: unknown, status = 200) {
   ) as unknown as typeof fetch;
 }
 
+// Counts only /api/rail/* calls out of a fetch mock — MiniGraph's own
+// graphDataURL fetch shares the same globalThis.fetch and would otherwise
+// inflate a spy meant to track Rail's own refetch-on-realm.changed behavior.
+function railCallCount(fetchSpy: ReturnType<typeof mock>): number {
+  return fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+    (typeof input === "string" ? input : input.toString()).includes("/rail/"),
+  ).length;
+}
+
 describe("Rail", () => {
+  let restoreScriptLoad: () => void;
+
+  beforeEach(() => {
+    restoreScriptLoad = stubScriptLoad();
+    (window as unknown as { cytoscape: ReturnType<typeof stubCytoscape> }).cytoscape = stubCytoscape();
+  });
+
   afterEach(() => {
     mock.restore();
-    // Rail mounts MiniGraph whenever a fixture carries graphDataURL, which
-    // drives the real (unstubbed here) loadScript("/vendor/cytoscape.min.js")
-    // path — happy-dom throws synchronously on the real script append, and
-    // that rejected promise stays cached at module scope unless cleared,
-    // short-circuiting any later file's stubbed load for the same src.
+    // Module-scope cache — reset so no test's script-load resolution leaks
+    // into a later file's own loadScript assertions.
     __resetLoadScriptCacheForTest();
+    restoreScriptLoad();
+    delete (window as { cytoscape?: unknown }).cytoscape;
   });
 
   test("renders nothing but the bare aside until page.resolved fires", () => {
@@ -168,13 +219,13 @@ describe("Rail", () => {
 
     events.emit("page.resolved", { relpath: "wiki/index.md" });
     await waitFor(() => expect(document.querySelector("#rail-props")).not.toBeNull());
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(railCallCount(fetchSpy)).toBe(1);
 
     await act(async () => {
       events.emit("realm.changed", { fp: "fp2", changed: ["wiki/index.md"] });
     });
 
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(railCallCount(fetchSpy)).toBe(2));
   });
 
   test("does not refetch on realm.changed when the open relpath is absent from a bounded changed list", async () => {
@@ -195,13 +246,13 @@ describe("Rail", () => {
 
     events.emit("page.resolved", { relpath: "wiki/index.md" });
     await waitFor(() => expect(document.querySelector("#rail-props")).not.toBeNull());
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(railCallCount(fetchSpy)).toBe(1);
 
     await act(async () => {
       events.emit("realm.changed", { fp: "fp2", changed: ["some/other.md"] });
     });
 
     await new Promise((r) => setTimeout(r, 20));
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(railCallCount(fetchSpy)).toBe(1);
   });
 });

--- a/atomic/internal/serve/frontend/src/pages/Page/Page.test.tsx
+++ b/atomic/internal/serve/frontend/src/pages/Page/Page.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { ApiProvider } from "../../utils/api";
 import { events } from "../../utils/events";
+import { __resetLoadScriptCacheForTest } from "../../utils/loadScript";
 import { Page } from "./Page";
 
 function renderAt(path: string) {
@@ -49,6 +50,12 @@ function stubScriptLoad() {
 describe("Page", () => {
   afterEach(() => {
     mock.restore();
+    // "mounts mermaid when hasMermaid is true" (below) drives the real
+    // loadScript("/vendor/mermaid.min.js") path — reset its module-level
+    // cache so a leaked resolved entry doesn't short-circuit
+    // loadScript.test.ts's own createCount() assertions in a later file.
+    __resetLoadScriptCacheForTest();
+    document.head.innerHTML = "";
   });
 
   test("skeleton renders before /api/page resolves — no blank flash", async () => {

--- a/atomic/internal/serve/frontend/src/test/setup.testing.ts
+++ b/atomic/internal/serve/frontend/src/test/setup.testing.ts
@@ -6,9 +6,19 @@
 import { afterEach, expect } from "bun:test";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
+import { __resetLoadScriptCacheForTest } from "../utils/loadScript";
 
 expect.extend(matchers);
 
 afterEach(() => {
   cleanup();
+  // loadScript's `loaded` Map and railCytoscapeStyle's `window.__railCy` are
+  // both module-level state shared across every test FILE in the process
+  // (bun:test does not reset modules between files). Individual suites that
+  // exercise the real script-load path (MiniGraph, Rail, mountMermaid, the
+  // App /graph route) already reset what they touch, but relying on every
+  // suite to remember is fragile — a leaked cache entry or leaked instance
+  // silently short-circuits an unrelated file's test. Reset centrally too.
+  __resetLoadScriptCacheForTest();
+  delete window.__railCy;
 });

--- a/docs/spec/sql-string-match.md
+++ b/docs/spec/sql-string-match.md
@@ -66,14 +66,14 @@ Covers builder-arg SQL fragments (ActiveRecord `where("title LIKE ?")`, GORM `Wh
 
 ## Checkpoints
 
-| # | Deliverable | Done when |
-|---|-------------|-----------|
-| 1 | C1: `sql_string` speculative harvest + callee capture (TS/TSX, Python, Go) + identifier filter + dedupe | Unit tests cover positive/negative literal shapes, owner attribution, callee capture per language, gate-passing literals untouched; `go test ./internal/codeintel/...` green |
-| 2 | C2 + C4 + C5: pass A object matching, vocabulary, provenance/metadata stamping, ambiguity cap, unmatched deletion | Unit tests cover high/medium tiers, case-insensitivity, ambiguity cap, non-SQL-node exclusion, ref cleanup; green |
-| 3 | C3: pass B qualified + anchored column matching | Unit tests cover qualified medium, anchored low, no-anchor never-emit, anchor scoping (wrong owner's anchor does not leak); green |
-| 4 | C6 + C7: MCP provenance parity, fixture corpus, end-to-end integration test | Integration test asserts the C7 edge set; full `go test ./...` green |
-| 5 | C8 fragment harvest: `sql_fragment` discriminator, fragment gate, tokenizer, stoplist, resolution-input exclusion | Unit tests cover gate boundaries (length cap, discriminator presence, prose rejection), tokenization (bare + qualified, keyword stoplist, dedupe), exclusion; green |
-| 6 | C8 resolution + C4 vocabulary expansion + C3 vocab column upgrade + fixture extension | Unit tests cover one-notch demotion at every tier, vocab column upgrade, both-kind C5 cleanup; e2e fixture gains fragment cases (where-fragment, order-DESC, comma pluck, prose negative) and asserts their edges; full `go test ./...` green |
+| # | Checkpoint | Files/areas | Verifies |
+|---|------------|-------------|----------|
+| 1 | C1: `sql_string` speculative harvest + callee capture (TS/TSX, Python, Go) + identifier filter + dedupe | `types/types.go`, `indexer/embedded_sql_postpass.go`, TS/Python/Go literal harvesters, `resolution/pipeline.go` | Unit tests cover positive/negative literal shapes, owner attribution, callee capture per language, gate-passing literals untouched; `go test ./internal/codeintel/...` green |
+| 2 | C2 + C4 + C5: pass A object matching, vocabulary, provenance/metadata stamping, ambiguity cap, unmatched deletion | `resolution/sql_string_match.go`, `extraction/standalone/query_builder_vocab.go`, `db/resolution.go` | Unit tests cover high/medium tiers, case-insensitivity, ambiguity cap, non-SQL-node exclusion, ref cleanup; green |
+| 3 | C3: pass B qualified + anchored column matching | `resolution/sql_string_match.go` | Unit tests cover qualified medium, anchored low, no-anchor never-emit, anchor scoping (wrong owner's anchor does not leak); green |
+| 4 | C6 + C7: MCP provenance parity, fixture corpus, end-to-end integration test | `mcp/server.go`, `scripts/code-eval/fixtures/sql-string-match/`, `engine` e2e test | Integration test asserts the C7 edge set; full `go test ./...` green |
+| 5 | C8 fragment harvest: `sql_fragment` discriminator, fragment gate, tokenizer, stoplist, resolution-input exclusion | `types/types.go`, `indexer/sql_fragment_harvest.go`, `indexer/embedded_sql_postpass.go` | Unit tests cover gate boundaries (length cap, discriminator presence, prose rejection), tokenization (bare + qualified, keyword stoplist, dedupe), exclusion; green |
+| 6 | C8 resolution + C4 vocabulary expansion + C3 vocab column upgrade + fixture extension | `resolution/sql_string_match.go`, `query_builder_vocab.go`, fixture + e2e test | Unit tests cover one-notch demotion at every tier, vocab column upgrade, both-kind C5 cleanup; e2e fixture gains fragment cases (where-fragment, order-DESC, comma pluck, prose negative) and asserts their edges; full `go test ./...` green |
 
 
 ## Implementation log


### PR DESCRIPTION
Every push to `next` since the serve-react refactor fails CI: the test job's `go generate ./...` hits the new bun frontend-build directive without bun installed, and two frontend tests are order-dependent flakes.

- test job gets `oven-sh/setup-bun@v2` (pinned 1.3.13, matching the frontend job) + frozen-lockfile install before Generate bundle; the bun build is deterministic so the committed-dist drift gate stays a no-op.
- Flakes root-caused to cross-file module-state leaks: `window.__railCy` never cleaned up by MiniGraph.test.tsx, and `loadScript`'s module-level promise cache poisoned with a rejected vendor-script entry by the Rail/Page suites. Fixed with per-file afterEach resets plus a central reset in setup.testing.ts. Verified under `bun test --randomize` across multiple seeds.