### PR TITLE
docs: align hero, meta, and README on one message

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -110,7 +110,7 @@ export default defineConfig({
     },
     appearance: 'force-dark',
     title: 'Atomic Claude',
-    description: 'An opinionated Claude Code configuration — compressed replies, idea-to-PR workflow, clean skill/command split.',
+    description: 'Code graphs, wikis, and research-backed agentic coding. Deterministic tools for nondeterministic workflows, in one opinionated Claude Code config.',
     srcDir: 'docs',
     base: '/',
     // Internal contract docs — kept in-repo for contributors, excluded from the public site.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
- <strong>An opinionated Claude Code configuration. Onboard Claude once: it maps your repo, ships features from issue to merged PR on autopilot, and sharpens its own setup from how you work.</strong>
+ <strong>Code graphs, wikis, and research-backed agentic coding. Deterministic tools for nondeterministic workflows, in one opinionated Claude Code config.</strong>
 </p>
 
 <p align="center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,22 +17,22 @@ hero:
 features:
     - icon: "\uE522"
       title: A code wiki your agent compiles
-      details: "Karpathy's LLM-wiki pattern at repo scale. Point an LLM at source material and it compiles a markdown wiki (per-area summaries, concept pages, an auto-maintained index) that it maintains itself and then reads instead of re-deriving the same answers. One scan builds that model of your codebase: framework, build and test commands, and a domain map of what lives where. Claude reads it before it reads your code, and ship commands keep it fresh."
+      details: "Claude compiles a markdown wiki of your repo: framework, build and test commands, a map of what lives where. It reads that before your code, and ship commands keep it current."
     - icon: "\uF542"
       title: A knowledge realm across repos
-      details: "A repo wiki maps one repo; a realm wiki maps a folder of them: services, libraries, or client projects, and how they relate. It is a working build of Karpathy's pattern one scale up, conforming to Google's Open Knowledge Format. /refresh-wiki points at the repos that already have a wiki, summarizes the ones that don't without touching them, and writes up the concerns they share. Capture buckets fold loose notes, research, and tickets into the same layer."
-    - icon: "\uE4E2"
-      title: See what Claude sees
-      details: "`atomic serve` opens the maps Claude navigates (wiki concepts and the code graph) as a browsable site on localhost. The Open Knowledge Format in practice for your repo: pages with a live right rail, a whole-system view colored by concept type, federated code search, and a source viewer wired to the code graph. Read-only, no auth, nothing leaves your machine."
+      details: "A folder of repos mapped as one knowledge base: per-repo summaries, the concerns they share, and capture buckets that fold in loose notes, research, and tickets."
     - icon: "\uF0E8"
       title: A code graph that speaks SQL
-      details: "One command parses your repo into a symbol graph across 31 languages and 23 web frameworks, no compiler required: definitions, callers, call sites, and the blast radius of any change. Claude queries the graph instead of grepping. SQL is a first-class citizen of that graph: Snowflake lineage, the dbt ref/source DAG, and T-SQL stored-procedure lineage down to the column, all static with no database connection, plus SQL pulled out of string literals across 20 host languages."
-    - icon: "\uF086"
-      title: Channels for your agents
-      details: "`atomic bus` gives concurrent Claude sessions named rooms to talk in. A session joins under its position (realm, repo, role) and receives its peers' messages as prompts. Every message carries an addressee list, which is what keeps a room of agents from answering each other's status updates forever: named means act, addressed to nobody means note it and move on. Watch, speak into, halt, or close any room from your own terminal."
+      details: "One command parses 31 languages into a symbol graph: definitions, callers, blast radius, no compiler needed. SQL is first-class, including Snowflake, dbt, and T-SQL lineage down to the column."
+    - icon: "\uE4E2"
+      title: See what Claude sees
+      details: "`atomic serve` opens the same maps Claude reads as a browsable site on localhost. Wiki pages, a whole-system graph, federated code search. Read-only, nothing leaves your machine."
     - icon: "\uF5B0"
       title: Autopilot, task to PR, hands-off
-      details: "Hand it a description or a GitHub issue number. It plans, implements with test-first subagents, checks blast radius against the code graph before each change, and reviews its own diff in a fresh context that never saw the reasoning. Grounded in the graph the whole way, not another autonomous agent guessing from grep. The only decision left to you is how to merge."
+      details: "Hand it a description or an issue number. It plans, implements test-first, checks blast radius against the graph, and reviews its own diff in a fresh context. You choose how to merge."
+    - icon: "\uF086"
+      title: Channels for your agents
+      details: "`atomic bus` gives concurrent Claude sessions named rooms. Every message carries an addressee list, so a room of agents notes the news instead of answering it forever."
 ---
 
 <div class="vp-doc home-extra">

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
     name: Atomic Claude
-    text: "A local code graph that grounds loops and wikis."
-    tagline: "31 languages, plus SQL lineage across Snowflake, dbt, and T-SQL. Local, free, MIT, never uploaded."
+    text: "Code graphs, wikis, and research-backed agentic coding."
+    tagline: "Deterministic tools for nondeterministic workflows. An opinionated Claude Code config that compiles the knowledge, indexes the graph, and runs the loop. Local and free."
     actions:
         - theme: brand
           text: Get Started


### PR DESCRIPTION
The hero sold the code graph. That is one of six feature cards, and the site meta description and README opener each said something different again, so GitHub → site → README handed a visitor three unrelated framings of the same tool.

Now one message on all three: the three pillars up top, then the determinism thesis the architecture already commits to. That second part is not a slogan — `CLAUDE.md` says code answers where code can, and the scan writes a deterministic substrate the model never hand-edits.

"Research-backed" is the claim `docs/credits.md` already backs, with two arXiv papers and caveman's measured token figure. Worth linking the phrase to `/credits` in a follow-up so it is evidence rather than an adjective.

Tagline drops the license and "never uploaded" to stay short.

Based on `main` rather than `next` — `next` is currently 4 commits behind, and the previous change to this page (5873025) landed on `main` too. Retarget if that is wrong.