### PR TITLE
feat(output-style): drop stock LLM phrasing from replies

### DIFF
--- a/atomic/internal/embedded/bundle/output-styles/atomic.md
+++ b/atomic/internal/embedded/bundle/output-styles/atomic.md
@@ -14,6 +14,7 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 
 - Condition before instruction.
 - Say it once — restatement is filler that survived word-cutting.
+- No AI tells. Stock LLM phrasing signals insight without adding any, and the reader has seen it a thousand times: "load-bearing", "here's the thing", "it's worth noting", "the real question is", "at its core", "let me be direct", "read that honestly", "genuinely", "meaningfully", "that's the actual X". Same for the contrastive reveal — "not X, it's Y", "isn't just X, it's Y" — which stages an insight instead of stating one. State the fact the tell was decorating.
 - Keep articles before surprising content; drop only where the noun is predictable.
 - Code fully answers -> code is the whole reply.
 - Keep the user's terms; don't rename their concepts.
@@ -34,6 +35,10 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 <example rule="say-once">
 <bad>Token expired, so auth fails. The failure comes from the expired token.</bad>
 <good>Token expired -> auth fails.</good>
+</example>
+<example rule="no-ai-tells">
+<bad>Here's the thing: pipeline order isn't just a detail, it's load-bearing.</bad>
+<good>Order matters: render writes `commands/`, bundle reads it.</good>
 </example>
 <example rule="surprising-articles">
 <bad>Rollback deletes backup.</bad>

--- a/atomic/internal/embedded/bundle/skills/atomic-documentation/SKILL.md
+++ b/atomic/internal/embedded/bundle/skills/atomic-documentation/SKILL.md
@@ -149,7 +149,7 @@ Generated docs are for humans navigating a codebase. Apply these standards:
 Quality checks:
 - Document *why*, not *what* — restating the code adds no value.
 - Break prose with a heading, table, diagram, or code block every ~15 lines.
-- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is LLM-tell.
+- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is LLM-tell. So are "load-bearing", "here's the thing", "it's worth noting", "at its core", "the real question is", and the contrastive reveal ("not X, it's Y"), which stages an insight instead of stating one. Cut the phrase, keep the fact. This check applies to both voices, including the terse-technical surfaces `atomic-writing` does not cover.
 - Note where generated pages should be linked so they're discoverable.
 - When updating a doc because the API changed, update all examples too.
 

--- a/atomic/internal/embedded/bundle/skills/atomic-writing/SKILL.md
+++ b/atomic/internal/embedded/bundle/skills/atomic-writing/SKILL.md
@@ -53,7 +53,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 
 4. **Show importance through content.** Delete "Full stop.", "Period.", "Let that sink in.", "Make no mistake.", "This matters because". Demonstrate why it matters, or let the reader judge.
 
-5. **Use plain words over business clichés.** Replace:
+5. **Use plain words over business clichés and stock LLM phrasing.** The second group is harder to catch because every individual word earns its place; the phrase is what fails. Replace:
 
     | Avoid | Use |
     |---|---|
@@ -67,10 +67,15 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
     | moving forward | next, from now |
     | at its core | (delete) |
     | in today's X | (delete) |
+    | load-bearing | name what breaks without it |
+    | it's worth noting | (delete, then state the note) |
+    | the real question is | state the question |
+    | that's the actual X | state X |
+    | read that honestly / to be honest | (delete) |
 
 6. **Use commas, periods, or parentheses.** Em dashes are an AI tell, and the comma or period is almost always clearer.
 
-7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
+7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`, `meaningfully`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
 
 8. **State the answer directly.** Skip "Not because X. Because Y.", "X isn't the problem. Y is.", "The question isn't X. It's Y." State Y without the dramatic setup.
 
@@ -97,6 +102,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 - Vague declarative ("the implications matter")? Name the implication or cut.
 - Three-item rhythm list (`speed, quality, cost`)? Drop to two, or break the rhythm.
 - Marketing word (game-changer, lean into, deep dive)? Replace.
+- Stock LLM phrase (load-bearing, it's worth noting, the real question is)? Cut it and state the fact it was decorating.
 - Inanimate noun doing a human verb? Name the human.
 - Throat-clearing opener ("Here's the thing")? Cut.
 - Binary-contrast structure ("not X. Y.")? State Y.

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -50,7 +50,7 @@ func Manifest() []Artifact {
 		{Kind: "rule", Source: "bundle/rules/typescript/style.md", Target: "rules/typescript/style.md", SHA256: "a520e9df348e06c5f0772d268a16ef03ea6fd2f77d6a2a192bf566b91db186d7"},
 		{Kind: "skill", Source: "bundle/skills/atomic-bus/SKILL.md", Target: "skills/atomic-bus/SKILL.md", SHA256: "4c86001346f3b0f4dce312365632a754edde5eb448ec15a9b4a5a1a821784437"},
 		{Kind: "skill", Source: "bundle/skills/atomic-debug/SKILL.md", Target: "skills/atomic-debug/SKILL.md", SHA256: "becc4cd2545a1a2755f08cf4da5135d4b7b930484137696476cba5805fded3c8"},
-		{Kind: "skill", Source: "bundle/skills/atomic-documentation/SKILL.md", Target: "skills/atomic-documentation/SKILL.md", SHA256: "6cb61140dd771e0b1457e693e2350cfb9b9ab4647ff03758e80bf1f6925bbd69"},
+		{Kind: "skill", Source: "bundle/skills/atomic-documentation/SKILL.md", Target: "skills/atomic-documentation/SKILL.md", SHA256: "ad48e5b96afdc27607d8b3fd6a89c03b4f4bb92405838fb79e072cd216b51375"},
 		{Kind: "skill", Source: "bundle/skills/atomic-git-discipline/SKILL.md", Target: "skills/atomic-git-discipline/SKILL.md", SHA256: "7a15ed26f4d5c52b1f921f18dff7a662502968cd81ae40bfa4ea8155e1098995"},
 		{Kind: "skill", Source: "bundle/skills/atomic-review/SKILL.md", Target: "skills/atomic-review/SKILL.md", SHA256: "5eab2efd6364adaa7b5d64687af819ffc658bf2295ec7e95739351bf7e4c3851"},
 		{Kind: "skill", Source: "bundle/skills/atomic-tdd/SKILL.md", Target: "skills/atomic-tdd/SKILL.md", SHA256: "8b5d6c0ef995a07d1b34f9fcee7647c446781e096894acb6713f53c610b452de"},
@@ -59,6 +59,6 @@ func Manifest() []Artifact {
 		{Kind: "skill", Source: "bundle/skills/atomic-wiki/SKILL.md", Target: "skills/atomic-wiki/SKILL.md", SHA256: "4ae2e4ca56d629736cc9c87b77ebcff64e2b93952cb9f592f347711b930bd2b5"},
 		{Kind: "skill", Source: "bundle/skills/atomic-wiki/references/realm.md", Target: "skills/atomic-wiki/references/realm.md", SHA256: "a5471720bb8c96b0da3746e6928594181aa702f638e5923441e3f2858f53b06d"},
 		{Kind: "skill", Source: "bundle/skills/atomic-wiki/references/repo.md", Target: "skills/atomic-wiki/references/repo.md", SHA256: "c85b50f7bdfedbe1ed3c2050064c399597f967cfc748362a66f368c43350fb5d"},
-		{Kind: "skill", Source: "bundle/skills/atomic-writing/SKILL.md", Target: "skills/atomic-writing/SKILL.md", SHA256: "9580cee4512874a74ea900647068eb4493d4806bfc1dbaa87351feaf732bc659"},
+		{Kind: "skill", Source: "bundle/skills/atomic-writing/SKILL.md", Target: "skills/atomic-writing/SKILL.md", SHA256: "9b117d1559944f34cfe024a82026a84c987dec6a9c90f523adc4b0ddae858288"},
 	}
 }

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -44,7 +44,7 @@ func Manifest() []Artifact {
 		{Kind: "command", Source: "bundle/commands/subagent-implementation.md", Target: "commands/subagent-implementation.md", SHA256: "606ea2473dca16bafe9c0553c04211dce319742b663ec5154662faaa96d65c0b"},
 		{Kind: "command", Source: "bundle/commands/undo-commit.md", Target: "commands/undo-commit.md", SHA256: "1fc57693e90c05a16866599703718863ecb7dbe31754ef210dbd2b73c487ea81"},
 		{Kind: "command", Source: "bundle/commands/watch-ci.md", Target: "commands/watch-ci.md", SHA256: "4097862c18d8f7ca68dddf01c45ca67bffac11529c086e188fa77d9109b82700"},
-		{Kind: "output-style", Source: "bundle/output-styles/atomic.md", Target: "output-styles/atomic.md", SHA256: "ae200a2e82300d508304e0bf9e9c1b13133fbb989efe2b5017fc6168b9c8ac49"},
+		{Kind: "output-style", Source: "bundle/output-styles/atomic.md", Target: "output-styles/atomic.md", SHA256: "e7f8c7a416624655fd63b49d44387ab2c02b0066988023868a90daf5a8ea921c"},
 		{Kind: "rule", Source: "bundle/rules/python/style.md", Target: "rules/python/style.md", SHA256: "79b5bc1f7b33e4f065e9645193eb6b3cb8227babb92c7e62ced0164673b0546b"},
 		{Kind: "rule", Source: "bundle/rules/specs/spec-currency.md", Target: "rules/specs/spec-currency.md", SHA256: "be29759d72debdf9589059ac7863746166a848aefc91412acb022107b557e218"},
 		{Kind: "rule", Source: "bundle/rules/typescript/style.md", Target: "rules/typescript/style.md", SHA256: "a520e9df348e06c5f0772d268a16ef03ea6fd2f77d6a2a192bf566b91db186d7"},

--- a/docs/reference/output-style.md
+++ b/docs/reference/output-style.md
@@ -22,10 +22,11 @@ The first four layers carry the load. The output style shapes how Claude communi
 
 ## Sentence rules
 
-Beyond the drop-list, five rules shape individual sentences. Each targets a redundancy that survives word-level cutting:
+Beyond the drop-list, six rules shape individual sentences. Each targets a redundancy that survives word-level cutting:
 
 - **Condition before instruction.** "If index stale, re-run indexer" scans in execution order. The trailing-condition form risks the reader acting before reading the guard.
 - **Say it once.** Restatement is the filler that word-cutting misses: the same proposition wearing a new sentence.
+- **No AI tells.** Stock LLM phrasing ("load-bearing", "here's the thing", "it's worth noting", "at its core") performs insight rather than delivering it, and the contrastive reveal ("not X, it's Y") stages a revelation around a fact that could just be stated. Both survive word-level cutting because every individual word earns its place. The rule targets the construction.
 - **Articles guard surprises.** Drop articles only where the noun is predictable. "Rollback deletes the backup" keeps its function words because the content is a warning, and a warning must parse on first read.
 - **Code can be the whole reply.** When code fully answers the question, prose around it adds nothing.
 - **Keep the user's terms.** Renaming their concepts mid-answer forces a mental cross-reference for zero gain.

--- a/output-styles/atomic.md
+++ b/output-styles/atomic.md
@@ -14,6 +14,7 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 
 - Condition before instruction.
 - Say it once — restatement is filler that survived word-cutting.
+- No AI tells. Stock LLM phrasing signals insight without adding any, and the reader has seen it a thousand times: "load-bearing", "here's the thing", "it's worth noting", "the real question is", "at its core", "let me be direct", "read that honestly", "genuinely", "meaningfully", "that's the actual X". Same for the contrastive reveal — "not X, it's Y", "isn't just X, it's Y" — which stages an insight instead of stating one. State the fact the tell was decorating.
 - Keep articles before surprising content; drop only where the noun is predictable.
 - Code fully answers -> code is the whole reply.
 - Keep the user's terms; don't rename their concepts.
@@ -34,6 +35,10 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 <example rule="say-once">
 <bad>Token expired, so auth fails. The failure comes from the expired token.</bad>
 <good>Token expired -> auth fails.</good>
+</example>
+<example rule="no-ai-tells">
+<bad>Here's the thing: pipeline order isn't just a detail, it's load-bearing.</bad>
+<good>Order matters: render writes `commands/`, bundle reads it.</good>
 </example>
 <example rule="surprising-articles">
 <bad>Rollback deletes backup.</bad>

--- a/skills/atomic-documentation/SKILL.md
+++ b/skills/atomic-documentation/SKILL.md
@@ -149,7 +149,7 @@ Generated docs are for humans navigating a codebase. Apply these standards:
 Quality checks:
 - Document *why*, not *what* — restating the code adds no value.
 - Break prose with a heading, table, diagram, or code block every ~15 lines.
-- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is LLM-tell.
+- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is LLM-tell. So are "load-bearing", "here's the thing", "it's worth noting", "at its core", "the real question is", and the contrastive reveal ("not X, it's Y"), which stages an insight instead of stating one. Cut the phrase, keep the fact. This check applies to both voices, including the terse-technical surfaces `atomic-writing` does not cover.
 - Note where generated pages should be linked so they're discoverable.
 - When updating a doc because the API changed, update all examples too.
 

--- a/skills/atomic-writing/SKILL.md
+++ b/skills/atomic-writing/SKILL.md
@@ -53,7 +53,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 
 4. **Show importance through content.** Delete "Full stop.", "Period.", "Let that sink in.", "Make no mistake.", "This matters because". Demonstrate why it matters, or let the reader judge.
 
-5. **Use plain words over business clichés.** Replace:
+5. **Use plain words over business clichés and stock LLM phrasing.** The second group is harder to catch because every individual word earns its place; the phrase is what fails. Replace:
 
     | Avoid | Use |
     |---|---|
@@ -67,10 +67,15 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
     | moving forward | next, from now |
     | at its core | (delete) |
     | in today's X | (delete) |
+    | load-bearing | name what breaks without it |
+    | it's worth noting | (delete, then state the note) |
+    | the real question is | state the question |
+    | that's the actual X | state X |
+    | read that honestly / to be honest | (delete) |
 
 6. **Use commas, periods, or parentheses.** Em dashes are an AI tell, and the comma or period is almost always clearer.
 
-7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
+7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`, `meaningfully`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
 
 8. **State the answer directly.** Skip "Not because X. Because Y.", "X isn't the problem. Y is.", "The question isn't X. It's Y." State Y without the dramatic setup.
 
@@ -97,6 +102,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 - Vague declarative ("the implications matter")? Name the implication or cut.
 - Three-item rhythm list (`speed, quality, cost`)? Drop to two, or break the rhythm.
 - Marketing word (game-changer, lean into, deep dive)? Replace.
+- Stock LLM phrase (load-bearing, it's worth noting, the real question is)? Cut it and state the fact it was decorating.
 - Inanimate noun doing a human verb? Name the human.
 - Throat-clearing opener ("Here's the thing")? Cut.
 - Binary-contrast structure ("not X. Y.")? State Y.


### PR DESCRIPTION
Adds a sixth sentence rule to the atomic output style, plus its bad/good example pair and the matching entry in the human-facing reference.

The existing drop-list works at word level (articles, filler, hedging). These tells survive it because each individual word is doing a job — it is the construction that fails. "Load-bearing", "here's the thing", "it's worth noting", "at its core", and the contrastive reveal ("not X, it's Y") stage a revelation around a fact that could simply be stated.

Scope is Claude's replies. The Boundaries section already exempts file contents, so this repo's own prose (`CLAUDE.local.md`, signals) keeps its existing usage.

Based on `main` rather than `next` for the same reason as #176 — `next` is currently behind.