### PR TITLE
fix: drop AI phrasing and align product messaging

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -110,7 +110,7 @@ export default defineConfig({
     },
     appearance: 'force-dark',
     title: 'Atomic Claude',
-    description: 'An opinionated Claude Code configuration — compressed replies, idea-to-PR workflow, clean skill/command split.',
+    description: 'Code graphs, wikis, and research-backed agentic coding. Deterministic tools for nondeterministic workflows, in one opinionated Claude Code config.',
     srcDir: 'docs',
     base: '/',
     // Internal contract docs — kept in-repo for contributors, excluded from the public site.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
- <strong>An opinionated Claude Code configuration. Onboard Claude once: it maps your repo, ships features from issue to merged PR on autopilot, and sharpens its own setup from how you work.</strong>
+ <strong>Code graphs, wikis, and research-backed agentic coding. Deterministic tools for nondeterministic workflows, in one opinionated Claude Code config.</strong>
 </p>
 
 <p align="center">

--- a/atomic/internal/embedded/bundle/output-styles/atomic.md
+++ b/atomic/internal/embedded/bundle/output-styles/atomic.md
@@ -14,6 +14,7 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 
 - Condition before instruction.
 - Say it once — restatement is filler that survived word-cutting.
+- Drop AI phrasing. These phrases signal insight without adding any, and the reader has seen them a thousand times: "load-bearing", "here's the thing", "it's worth noting", "the real question is", "at its core", "let me be direct", "read that honestly", "genuinely", "meaningfully", "that's the actual X". Same for the contrastive reveal — "not X, it's Y", "isn't just X, it's Y" — which stages an insight instead of stating one. State the fact the phrasing was decorating.
 - Keep articles before surprising content; drop only where the noun is predictable.
 - Code fully answers -> code is the whole reply.
 - Keep the user's terms; don't rename their concepts.
@@ -34,6 +35,10 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 <example rule="say-once">
 <bad>Token expired, so auth fails. The failure comes from the expired token.</bad>
 <good>Token expired -> auth fails.</good>
+</example>
+<example rule="drop-ai-phrasing">
+<bad>Here's the thing: pipeline order isn't just a detail, it's load-bearing.</bad>
+<good>Order matters: render writes `commands/`, bundle reads it.</good>
 </example>
 <example rule="surprising-articles">
 <bad>Rollback deletes backup.</bad>

--- a/atomic/internal/embedded/bundle/skills/atomic-documentation/SKILL.md
+++ b/atomic/internal/embedded/bundle/skills/atomic-documentation/SKILL.md
@@ -149,7 +149,7 @@ Generated docs are for humans navigating a codebase. Apply these standards:
 Quality checks:
 - Document *why*, not *what* — restating the code adds no value.
 - Break prose with a heading, table, diagram, or code block every ~15 lines.
-- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is LLM-tell.
+- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is AI phrasing. So are "load-bearing", "here's the thing", "it's worth noting", "at its core", "the real question is", and the contrastive reveal ("not X, it's Y"), which stages an insight instead of stating one. Cut the phrase, keep the fact. This check applies to both voices, including the terse-technical surfaces `atomic-writing` does not cover.
 - Note where generated pages should be linked so they're discoverable.
 - When updating a doc because the API changed, update all examples too.
 

--- a/atomic/internal/embedded/bundle/skills/atomic-writing/SKILL.md
+++ b/atomic/internal/embedded/bundle/skills/atomic-writing/SKILL.md
@@ -53,7 +53,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 
 4. **Show importance through content.** Delete "Full stop.", "Period.", "Let that sink in.", "Make no mistake.", "This matters because". Demonstrate why it matters, or let the reader judge.
 
-5. **Use plain words over business clichés.** Replace:
+5. **Use plain words over business clichés and stock AI phrasing.** The second group is harder to catch because every individual word earns its place; the phrase is what fails. Replace:
 
     | Avoid | Use |
     |---|---|
@@ -67,10 +67,15 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
     | moving forward | next, from now |
     | at its core | (delete) |
     | in today's X | (delete) |
+    | load-bearing | name what breaks without it |
+    | it's worth noting | (delete, then state the note) |
+    | the real question is | state the question |
+    | that's the actual X | state X |
+    | read that honestly / to be honest | (delete) |
 
 6. **Use commas, periods, or parentheses.** Em dashes are an AI tell, and the comma or period is almost always clearer.
 
-7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
+7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`, `meaningfully`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
 
 8. **State the answer directly.** Skip "Not because X. Because Y.", "X isn't the problem. Y is.", "The question isn't X. It's Y." State Y without the dramatic setup.
 
@@ -97,6 +102,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 - Vague declarative ("the implications matter")? Name the implication or cut.
 - Three-item rhythm list (`speed, quality, cost`)? Drop to two, or break the rhythm.
 - Marketing word (game-changer, lean into, deep dive)? Replace.
+- Stock AI phrase (load-bearing, it's worth noting, the real question is)? Cut it and state the fact it was decorating.
 - Inanimate noun doing a human verb? Name the human.
 - Throat-clearing opener ("Here's the thing")? Cut.
 - Binary-contrast structure ("not X. Y.")? State Y.

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -44,13 +44,13 @@ func Manifest() []Artifact {
 		{Kind: "command", Source: "bundle/commands/subagent-implementation.md", Target: "commands/subagent-implementation.md", SHA256: "606ea2473dca16bafe9c0553c04211dce319742b663ec5154662faaa96d65c0b"},
 		{Kind: "command", Source: "bundle/commands/undo-commit.md", Target: "commands/undo-commit.md", SHA256: "1fc57693e90c05a16866599703718863ecb7dbe31754ef210dbd2b73c487ea81"},
 		{Kind: "command", Source: "bundle/commands/watch-ci.md", Target: "commands/watch-ci.md", SHA256: "4097862c18d8f7ca68dddf01c45ca67bffac11529c086e188fa77d9109b82700"},
-		{Kind: "output-style", Source: "bundle/output-styles/atomic.md", Target: "output-styles/atomic.md", SHA256: "ae200a2e82300d508304e0bf9e9c1b13133fbb989efe2b5017fc6168b9c8ac49"},
+		{Kind: "output-style", Source: "bundle/output-styles/atomic.md", Target: "output-styles/atomic.md", SHA256: "3aac10a9c567e8e8581a8d7248a51ddca85b0771382d0690f7a8b4dd9ed61233"},
 		{Kind: "rule", Source: "bundle/rules/python/style.md", Target: "rules/python/style.md", SHA256: "79b5bc1f7b33e4f065e9645193eb6b3cb8227babb92c7e62ced0164673b0546b"},
 		{Kind: "rule", Source: "bundle/rules/specs/spec-currency.md", Target: "rules/specs/spec-currency.md", SHA256: "be29759d72debdf9589059ac7863746166a848aefc91412acb022107b557e218"},
 		{Kind: "rule", Source: "bundle/rules/typescript/style.md", Target: "rules/typescript/style.md", SHA256: "a520e9df348e06c5f0772d268a16ef03ea6fd2f77d6a2a192bf566b91db186d7"},
 		{Kind: "skill", Source: "bundle/skills/atomic-bus/SKILL.md", Target: "skills/atomic-bus/SKILL.md", SHA256: "4c86001346f3b0f4dce312365632a754edde5eb448ec15a9b4a5a1a821784437"},
 		{Kind: "skill", Source: "bundle/skills/atomic-debug/SKILL.md", Target: "skills/atomic-debug/SKILL.md", SHA256: "becc4cd2545a1a2755f08cf4da5135d4b7b930484137696476cba5805fded3c8"},
-		{Kind: "skill", Source: "bundle/skills/atomic-documentation/SKILL.md", Target: "skills/atomic-documentation/SKILL.md", SHA256: "6cb61140dd771e0b1457e693e2350cfb9b9ab4647ff03758e80bf1f6925bbd69"},
+		{Kind: "skill", Source: "bundle/skills/atomic-documentation/SKILL.md", Target: "skills/atomic-documentation/SKILL.md", SHA256: "1a5e5d574dce3f0270ebedddf1d712f89687a5f3453141387a04f4aa81fd774d"},
 		{Kind: "skill", Source: "bundle/skills/atomic-git-discipline/SKILL.md", Target: "skills/atomic-git-discipline/SKILL.md", SHA256: "7a15ed26f4d5c52b1f921f18dff7a662502968cd81ae40bfa4ea8155e1098995"},
 		{Kind: "skill", Source: "bundle/skills/atomic-review/SKILL.md", Target: "skills/atomic-review/SKILL.md", SHA256: "5eab2efd6364adaa7b5d64687af819ffc658bf2295ec7e95739351bf7e4c3851"},
 		{Kind: "skill", Source: "bundle/skills/atomic-tdd/SKILL.md", Target: "skills/atomic-tdd/SKILL.md", SHA256: "8b5d6c0ef995a07d1b34f9fcee7647c446781e096894acb6713f53c610b452de"},
@@ -59,6 +59,6 @@ func Manifest() []Artifact {
 		{Kind: "skill", Source: "bundle/skills/atomic-wiki/SKILL.md", Target: "skills/atomic-wiki/SKILL.md", SHA256: "4ae2e4ca56d629736cc9c87b77ebcff64e2b93952cb9f592f347711b930bd2b5"},
 		{Kind: "skill", Source: "bundle/skills/atomic-wiki/references/realm.md", Target: "skills/atomic-wiki/references/realm.md", SHA256: "a5471720bb8c96b0da3746e6928594181aa702f638e5923441e3f2858f53b06d"},
 		{Kind: "skill", Source: "bundle/skills/atomic-wiki/references/repo.md", Target: "skills/atomic-wiki/references/repo.md", SHA256: "c85b50f7bdfedbe1ed3c2050064c399597f967cfc748362a66f368c43350fb5d"},
-		{Kind: "skill", Source: "bundle/skills/atomic-writing/SKILL.md", Target: "skills/atomic-writing/SKILL.md", SHA256: "9580cee4512874a74ea900647068eb4493d4806bfc1dbaa87351feaf732bc659"},
+		{Kind: "skill", Source: "bundle/skills/atomic-writing/SKILL.md", Target: "skills/atomic-writing/SKILL.md", SHA256: "670fa37a5d70b6572d2b9062fd08304070e8ce2c7b37f7b31d14cff54c3b5051"},
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
     name: Atomic Claude
-    text: "A local code graph that grounds loops and wikis."
-    tagline: "31 languages, plus SQL lineage across Snowflake, dbt, and T-SQL. Local, free, MIT, never uploaded."
+    text: "Code graphs, wikis, and research-backed agentic coding."
+    tagline: "Deterministic tools for nondeterministic workflows. An opinionated Claude Code config that compiles the knowledge, indexes the graph, and runs the loop. Local and free."
     actions:
         - theme: brand
           text: Get Started
@@ -17,22 +17,22 @@ hero:
 features:
     - icon: "\uE522"
       title: A code wiki your agent compiles
-      details: "Karpathy's LLM-wiki pattern at repo scale. Point an LLM at source material and it compiles a markdown wiki (per-area summaries, concept pages, an auto-maintained index) that it maintains itself and then reads instead of re-deriving the same answers. One scan builds that model of your codebase: framework, build and test commands, and a domain map of what lives where. Claude reads it before it reads your code, and ship commands keep it fresh."
+      details: "Claude compiles a markdown wiki of your repo: framework, build and test commands, a map of what lives where. It reads that before your code, and ship commands keep it current."
     - icon: "\uF542"
       title: A knowledge realm across repos
-      details: "A repo wiki maps one repo; a realm wiki maps a folder of them: services, libraries, or client projects, and how they relate. It is a working build of Karpathy's pattern one scale up, conforming to Google's Open Knowledge Format. /refresh-wiki points at the repos that already have a wiki, summarizes the ones that don't without touching them, and writes up the concerns they share. Capture buckets fold loose notes, research, and tickets into the same layer."
-    - icon: "\uE4E2"
-      title: See what Claude sees
-      details: "`atomic serve` opens the maps Claude navigates (wiki concepts and the code graph) as a browsable site on localhost. The Open Knowledge Format in practice for your repo: pages with a live right rail, a whole-system view colored by concept type, federated code search, and a source viewer wired to the code graph. Read-only, no auth, nothing leaves your machine."
+      details: "A folder of repos mapped as one knowledge base: per-repo summaries, the concerns they share, and capture buckets that fold in loose notes, research, and tickets."
     - icon: "\uF0E8"
       title: A code graph that speaks SQL
-      details: "One command parses your repo into a symbol graph across 31 languages and 23 web frameworks, no compiler required: definitions, callers, call sites, and the blast radius of any change. Claude queries the graph instead of grepping. SQL is a first-class citizen of that graph: Snowflake lineage, the dbt ref/source DAG, and T-SQL stored-procedure lineage down to the column, all static with no database connection, plus SQL pulled out of string literals across 20 host languages."
-    - icon: "\uF086"
-      title: Channels for your agents
-      details: "`atomic bus` gives concurrent Claude sessions named rooms to talk in. A session joins under its position (realm, repo, role) and receives its peers' messages as prompts. Every message carries an addressee list, which is what keeps a room of agents from answering each other's status updates forever: named means act, addressed to nobody means note it and move on. Watch, speak into, halt, or close any room from your own terminal."
+      details: "One command parses 31 languages into a symbol graph: definitions, callers, blast radius, no compiler needed. SQL is first-class, including Snowflake, dbt, and T-SQL lineage down to the column."
+    - icon: "\uE4E2"
+      title: See what Claude sees
+      details: "`atomic serve` opens the same maps Claude reads as a browsable site on localhost. Wiki pages, a whole-system graph, federated code search. Read-only, nothing leaves your machine."
     - icon: "\uF5B0"
       title: Autopilot, task to PR, hands-off
-      details: "Hand it a description or a GitHub issue number. It plans, implements with test-first subagents, checks blast radius against the code graph before each change, and reviews its own diff in a fresh context that never saw the reasoning. Grounded in the graph the whole way, not another autonomous agent guessing from grep. The only decision left to you is how to merge."
+      details: "Hand it a description or an issue number. It plans, implements test-first, checks blast radius against the graph, and reviews its own diff in a fresh context. You choose how to merge."
+    - icon: "\uF086"
+      title: Channels for your agents
+      details: "`atomic bus` gives concurrent Claude sessions named rooms. Every message carries an addressee list, so a room of agents notes the news instead of answering it forever."
 ---
 
 <div class="vp-doc home-extra">

--- a/docs/reference/output-style.md
+++ b/docs/reference/output-style.md
@@ -22,10 +22,11 @@ The first four layers carry the load. The output style shapes how Claude communi
 
 ## Sentence rules
 
-Beyond the drop-list, five rules shape individual sentences. Each targets a redundancy that survives word-level cutting:
+Beyond the drop-list, six rules shape individual sentences. Each targets a redundancy that survives word-level cutting:
 
 - **Condition before instruction.** "If index stale, re-run indexer" scans in execution order. The trailing-condition form risks the reader acting before reading the guard.
 - **Say it once.** Restatement is the filler that word-cutting misses: the same proposition wearing a new sentence.
+- **Drop AI phrasing.** Stock phrases ("load-bearing", "here's the thing", "it's worth noting", "at its core") perform insight rather than delivering it, and the contrastive reveal ("not X, it's Y") stages a revelation around a fact that could just be stated. Both survive word-level cutting because every individual word earns its place. The rule targets the phrasing, not the fact underneath it.
 - **Articles guard surprises.** Drop articles only where the noun is predictable. "Rollback deletes the backup" keeps its function words because the content is a warning, and a warning must parse on first read.
 - **Code can be the whole reply.** When code fully answers the question, prose around it adds nothing.
 - **Keep the user's terms.** Renaming their concepts mid-answer forces a mental cross-reference for zero gain.

--- a/output-styles/atomic.md
+++ b/output-styles/atomic.md
@@ -14,6 +14,7 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 
 - Condition before instruction.
 - Say it once — restatement is filler that survived word-cutting.
+- Drop AI phrasing. These phrases signal insight without adding any, and the reader has seen them a thousand times: "load-bearing", "here's the thing", "it's worth noting", "the real question is", "at its core", "let me be direct", "read that honestly", "genuinely", "meaningfully", "that's the actual X". Same for the contrastive reveal — "not X, it's Y", "isn't just X, it's Y" — which stages an insight instead of stating one. State the fact the phrasing was decorating.
 - Keep articles before surprising content; drop only where the noun is predictable.
 - Code fully answers -> code is the whole reply.
 - Keep the user's terms; don't rename their concepts.
@@ -34,6 +35,10 @@ Pattern: `[thing] [action] [reason if non-obvious]. [next step].`
 <example rule="say-once">
 <bad>Token expired, so auth fails. The failure comes from the expired token.</bad>
 <good>Token expired -> auth fails.</good>
+</example>
+<example rule="drop-ai-phrasing">
+<bad>Here's the thing: pipeline order isn't just a detail, it's load-bearing.</bad>
+<good>Order matters: render writes `commands/`, bundle reads it.</good>
 </example>
 <example rule="surprising-articles">
 <bad>Rollback deletes backup.</bad>

--- a/skills/atomic-documentation/SKILL.md
+++ b/skills/atomic-documentation/SKILL.md
@@ -149,7 +149,7 @@ Generated docs are for humans navigating a codebase. Apply these standards:
 Quality checks:
 - Document *why*, not *what* — restating the code adds no value.
 - Break prose with a heading, table, diagram, or code block every ~15 lines.
-- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is LLM-tell.
+- Write direct and specific — "This comprehensive guide provides an in-depth overview of..." is AI phrasing. So are "load-bearing", "here's the thing", "it's worth noting", "at its core", "the real question is", and the contrastive reveal ("not X, it's Y"), which stages an insight instead of stating one. Cut the phrase, keep the fact. This check applies to both voices, including the terse-technical surfaces `atomic-writing` does not cover.
 - Note where generated pages should be linked so they're discoverable.
 - When updating a doc because the API changed, update all examples too.
 

--- a/skills/atomic-writing/SKILL.md
+++ b/skills/atomic-writing/SKILL.md
@@ -53,7 +53,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 
 4. **Show importance through content.** Delete "Full stop.", "Period.", "Let that sink in.", "Make no mistake.", "This matters because". Demonstrate why it matters, or let the reader judge.
 
-5. **Use plain words over business clichés.** Replace:
+5. **Use plain words over business clichés and stock AI phrasing.** The second group is harder to catch because every individual word earns its place; the phrase is what fails. Replace:
 
     | Avoid | Use |
     |---|---|
@@ -67,10 +67,15 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
     | moving forward | next, from now |
     | at its core | (delete) |
     | in today's X | (delete) |
+    | load-bearing | name what breaks without it |
+    | it's worth noting | (delete, then state the note) |
+    | the real question is | state the question |
+    | that's the actual X | state X |
+    | read that honestly / to be honest | (delete) |
 
 6. **Use commas, periods, or parentheses.** Em dashes are an AI tell, and the comma or period is almost always clearer.
 
-7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
+7. **Cut filler adverbs.** Remove `really`, `just`, `literally`, `genuinely`, `honestly`, `simply`, `actually`, `truly`, `deeply`, `fundamentally`, `inherently`, `inevitably`, `interestingly`, `importantly`, `crucially`, `meaningfully`. Keep `-ly` words only when they carry technical meaning (`asynchronously`, `recursively`).
 
 8. **State the answer directly.** Skip "Not because X. Because Y.", "X isn't the problem. Y is.", "The question isn't X. It's Y." State Y without the dramatic setup.
 
@@ -97,6 +102,7 @@ Two voices. The atomic output style (`output-styles/atomic.md`) covers Claude's 
 - Vague declarative ("the implications matter")? Name the implication or cut.
 - Three-item rhythm list (`speed, quality, cost`)? Drop to two, or break the rhythm.
 - Marketing word (game-changer, lean into, deep dive)? Replace.
+- Stock AI phrase (load-bearing, it's worth noting, the real question is)? Cut it and state the fact it was decorating.
 - Inanimate noun doing a human verb? Name the human.
 - Throat-clearing opener ("Here's the thing")? Cut.
 - Binary-contrast structure ("not X. Y.")? State Y.


### PR DESCRIPTION
Supersedes #176 and #177, squashed into one commit so release-please surfaces it.

**Messaging.** The hero sold the code graph, which is one of six feature cards, while the site meta description and the README opener each said something different. A visitor going GitHub → site → README got three unrelated framings. All three now carry the same sentence, and the GitHub repo description was updated to match. Home cards reorder to learn/see/do and drop from roughly 90 words each to 25, because titles are what a visitor actually reads.

**Phrasing.** A new style rule cuts stock AI phrasing from replies. The existing drop-list works at word level, so it misses these: every individual word earns its place and the phrase is what fails. `atomic-writing` already covered the constructions in rules 3, 8, and 9, so it gains vocabulary only rather than a rule repeating what is there. `atomic-documentation` carries the check to terse-technical surfaces, which `atomic-writing` explicitly excludes.

Labelled `fix:` so it lands in the changelog; `docs:` would have been filtered.