### PR TITLE
fix(code): replace __serve verb with mcp --daemon flag

### DIFF
--- a/atomic/cmd/atomic/main.go
+++ b/atomic/cmd/atomic/main.go
@@ -817,7 +817,10 @@ func buildCodeCmd(repoOverride *string) *cobra.Command {
 		c.Flags().String("only", "", "include only files matching pattern")
 		c.Flags().String("exclude", "", "exclude files matching pattern")
 	})
-	addSub("mcp", "Run the MCP server over stdio (proxy + daemon; --no-watch disables sync poller)", "", func(c *cobra.Command) {
+	addSub("mcp", "Run the MCP server over stdio (proxy by default; --daemon --source --db runs the daemon itself; --no-watch disables sync poller)", "", func(c *cobra.Command) {
+		c.Flags().Bool("daemon", false, "run as the daemon itself, bound to --source/--db")
+		c.Flags().String("source", "", "source root to serve (requires --daemon)")
+		c.Flags().String("db", "", "absolute path to the SQLite index db (requires --daemon)")
 		c.Flags().Duration("watch-interval", 0, "override the daemon's sync interval")
 		c.Flags().Bool("no-watch", false, "disable background sync poller in the daemon")
 	})

--- a/atomic/cmd/atomic/main_test.go
+++ b/atomic/cmd/atomic/main_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/damusix/atomic-claude/atomic/internal/bus"
 	"github.com/damusix/atomic-claude/atomic/internal/cliusage"
+	codemcp "github.com/damusix/atomic-claude/atomic/internal/codeintel/mcp"
 	"github.com/damusix/atomic-claude/atomic/internal/config"
 	"github.com/damusix/atomic-claude/atomic/internal/docs"
 	"github.com/damusix/atomic-claude/atomic/internal/doctemplate"
@@ -114,7 +115,7 @@ var cp3WantMeta = []struct {
 	{[]string{"code", "files"}, "[pattern]", "List indexed files"},
 	{[]string{"code", "affected"}, "", "Find affected test files"},
 	{[]string{"code", "explore"}, "<query>", "Gather context for a query"},
-	{[]string{"code", "mcp"}, "", "Run the MCP server over stdio (proxy + daemon; --no-watch disables sync poller)"},
+	{[]string{"code", "mcp"}, "", "Run the MCP server over stdio (proxy by default; --daemon --source --db runs the daemon itself; --no-watch disables sync poller)"},
 	// config subcommands
 	{[]string{"config", "get"}, "<key>", "Print resolved config value"},
 	{[]string{"config", "set"}, "<key> <val>", "Set config value; re-renders config.resolved.md"},
@@ -385,6 +386,64 @@ func TestRunBus_DispatchUsesRealHomeFromEnv(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"probe"`) {
 		t.Errorf("subprocess output does not contain the seeded member; got:\n%s", out)
+	}
+}
+
+// TestCodeMCPDaemonArgv_MatchesCobraTree is the GitHub issue #193 regression
+// test: DefaultSpawn's argv (codemcp.DaemonArgv) must always name a
+// Cobra-registered command, or the spawned daemon subprocess dies on
+// "unknown flag" before its handler ever runs — the only symptom being
+// "daemon did not start within 10s" at the proxy. Driving DaemonArgv's own
+// output through the real root command (rather than hand-writing the argv
+// here) means a future drift between DefaultSpawn and the Cobra tree fails
+// this test instead of silently reintroducing the bug.
+//
+// runCode calls os.Exit, so the dispatch is exercised in a subprocess (the
+// standard Go idiom for os.Exit-calling code), matching
+// TestRunBus_DispatchUsesRealHomeFromEnv's established pattern.
+func TestCodeMCPDaemonArgv_MatchesCobraTree(t *testing.T) {
+	if os.Getenv("ATOMIC_TEST_CODE_MCP_DAEMON_ARGV_HELPER") == "1" {
+		var repoOverride string
+		root := buildRootCmd(&repoOverride)
+		root.SetArgs(codemcp.DaemonArgv(os.Getenv("ATOMIC_TEST_MCP_SRC"), os.Getenv("ATOMIC_TEST_MCP_DB"), codemcp.WatchOptions{}))
+		if err := root.Execute(); err != nil {
+			// Mirrors main()'s own Execute() error handling so the subprocess's
+			// stderr/exit code match what a real invocation would produce.
+			fmt.Fprintf(os.Stderr, "atomic: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// dbPath's parent path component is a regular file, not a directory: the
+	// daemon handler's own MkdirAll fails fast and deterministically (no
+	// accept loop ever starts, no socket ever binds), giving a handler-level
+	// error to assert against instead of racing a real daemon's lifetime.
+	tmp := t.TempDir()
+	blocker := filepath.Join(tmp, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	dbPath := filepath.Join(blocker, "sub", "atomic.db")
+	srcDir := t.TempDir()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCodeMCPDaemonArgv_MatchesCobraTree")
+	cmd.Env = append(os.Environ(),
+		"ATOMIC_TEST_CODE_MCP_DAEMON_ARGV_HELPER=1",
+		"ATOMIC_TEST_MCP_SRC="+srcDir,
+		"ATOMIC_TEST_MCP_DB="+dbPath,
+	)
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+
+	if strings.Contains(output, "unknown flag") {
+		t.Fatalf("DaemonArgv produced args Cobra could not parse (spawn/cobra-tree drift):\n%s", output)
+	}
+	if err == nil {
+		t.Fatalf("expected the daemon handler to fail on an unusable db path, got success:\n%s", output)
+	}
+	if !strings.Contains(output, "atomic code mcp:") {
+		t.Errorf("expected the handler's own \"atomic code mcp:\" error prefix, got:\n%s", output)
 	}
 }
 

--- a/atomic/internal/cliusage/cliusage.go
+++ b/atomic/internal/cliusage/cliusage.go
@@ -439,8 +439,8 @@ var commands = []Command{
 	{
 		Path:        []string{"code", "mcp"},
 		Args:        "",
-		Flags:       []string{"--watch-interval", "--no-watch"},
-		Description: "Run the MCP server over stdio (proxy + daemon; --no-watch disables sync poller)",
+		Flags:       []string{"--daemon", "--source", "--db", "--watch-interval", "--no-watch"},
+		Description: "Run the MCP server over stdio (proxy by default; --daemon --source --db runs the daemon itself; --no-watch disables sync poller)",
 	},
 	{
 		Path:        []string{"wiki", "scan"},

--- a/atomic/internal/codeintel/cli/code.go
+++ b/atomic/internal/codeintel/cli/code.go
@@ -44,12 +44,6 @@ func RunCode(args []string, projectRoot string, stdout, stderr io.Writer, stdin 
 	rest := args[1:]
 	ctx := context.Background()
 
-	// Internal verb: `atomic code __serve <projectRoot>` — spawned by the proxy
-	// auto-start path. Not advertised in help; not user-facing.
-	if verb == "__serve" {
-		return runServe(ctx, rest, stderr)
-	}
-
 	// `atomic code mcp` is the proxy path (CP23): connect-or-start the daemon,
 	// then pipe stdin↔socket. Does not need the pre-created engine.
 	// dbPath for standalone repo: <projectRoot>/.claude/.atomic-index/atomic.db.
@@ -113,7 +107,7 @@ func printCodeUsage(w io.Writer) {
 	fmt.Fprintln(w, "  files     List indexed files (optional path/pattern filter)")
 	fmt.Fprintln(w, "  affected  Find test files transitively affected by changed files")
 	fmt.Fprintln(w, "  explore   Gather relevant context for a query (markdown output)")
-	fmt.Fprintln(w, "  mcp       Run the MCP server over stdio")
+	fmt.Fprintln(w, "  mcp       Run the MCP server over stdio (--daemon runs the auto-started server itself)")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "All query verbs accept --json for machine-readable output.")
 	fmt.Fprintln(w, "DB path: "+config.IndexDBPath("<project>"))
@@ -1009,54 +1003,59 @@ func EnsureGitignore(projectRoot string) error {
 // mcp
 // ---------------------------------------------------------------------------
 
-// runMCP is the proxy path for `atomic code mcp` (CP23).
-// It connect-or-starts the singleton daemon (flock-guarded auto-start) and
-// then bidirectionally pipes stdin↔socket / stdout↔socket.
-// The daemon stays alive when the proxy exits; a second call reuses the warm engine.
+// runMCP is `atomic code mcp` (CP23, GitHub issue #193).
 //
-// projectRoot is the source tree root; dbPath is where the index lives. Both
-// are resolved by main.go (realm-aware) before calling here.
+// Without --daemon it is the proxy path: connect-or-start the singleton
+// daemon (flock-guarded auto-start) and then bidirectionally pipe
+// stdin↔socket / stdout↔socket. The daemon stays alive when the proxy exits;
+// a second call reuses the warm engine.
+//
+// With --daemon this process IS the daemon: DefaultSpawn execs exactly this
+// invocation (see mcp.DaemonArgv) with explicit --source/--db so the daemon
+// never re-resolves scope from the process cwd. Folding daemon mode into the
+// already-registered mcp verb — instead of a separate internal verb — means
+// the spawned argv always names a real Cobra command; the old unregistered
+// internal verb used to make Cobra reject the spawn's own flags with
+// "unknown flag" before the daemon handler ever ran (GitHub issue #193).
+//
+// projectRoot/dbPath are the proxy-mode source+db, resolved by main.go
+// (realm-aware) before calling here; they are ignored when --daemon is set,
+// in favor of the explicit --source/--db flags.
 func runMCP(ctx context.Context, projectRoot, dbPath string, args []string, stderr io.Writer) int {
 	fs := flag.NewFlagSet("code mcp", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	cliutil.SetUsage(fs, "atomic code mcp [--watch-interval <dur>] [--no-watch]")
+	cliutil.SetUsage(fs, "atomic code mcp [--daemon --source <path> --db <path>] [--watch-interval <dur>] [--no-watch]")
+	var daemon bool
+	var sourceRoot, explicitDB string
 	var watchInterval time.Duration
 	var noWatch bool
+	fs.BoolVar(&daemon, "daemon", false, "run as the daemon itself, bound to --source/--db (spawned by the proxy auto-start path)")
+	fs.StringVar(&sourceRoot, "source", "", "source root to serve (requires --daemon)")
+	fs.StringVar(&explicitDB, "db", "", "absolute path to the SQLite index db (requires --daemon)")
 	fs.DurationVar(&watchInterval, "watch-interval", 0, "override the daemon's sync interval (default 10s)")
 	fs.BoolVar(&noWatch, "no-watch", false, "disable background sync poller in the daemon")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	opts := codemcp.WatchOptions{
-		Disable:  noWatch,
-		Interval: watchInterval,
+	if !daemon {
+		if sourceRoot != "" || explicitDB != "" {
+			fmt.Fprintln(stderr, "atomic code mcp: --source/--db require --daemon")
+			return 1
+		}
+		opts := codemcp.WatchOptions{
+			Disable:  noWatch,
+			Interval: watchInterval,
+		}
+		if err := codemcp.RunProxy(ctx, projectRoot, dbPath, opts, nil, os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintf(stderr, "atomic code mcp: %v\n", err)
+			return 1
+		}
+		return 0
 	}
-	if err := codemcp.RunProxy(ctx, projectRoot, dbPath, opts, nil, os.Stdin, os.Stdout); err != nil {
-		fmt.Fprintf(stderr, "atomic code mcp: %v\n", err)
-		return 1
-	}
-	return 0
-}
 
-// runServe is the internal daemon entry point, invoked only by the auto-start
-// proxy via `atomic code __serve --source SRC --db DB`. Not user-facing; not in help.
-// Explicit source+db make the daemon cwd-independent (the key fix).
-func runServe(ctx context.Context, args []string, stderr io.Writer) int {
-	fs := flag.NewFlagSet("code __serve", flag.ContinueOnError)
-	fs.SetOutput(stderr)
-	var sourceRoot, dbPath string
-	var watchInterval time.Duration
-	var noWatch bool
-	fs.StringVar(&sourceRoot, "source", "", "source root to serve (required)")
-	fs.StringVar(&dbPath, "db", "", "absolute path to the SQLite index db (required)")
-	fs.DurationVar(&watchInterval, "watch-interval", 0, "override the daemon's sync interval (default 10s)")
-	fs.BoolVar(&noWatch, "no-watch", false, "disable background sync poller")
-	if err := fs.Parse(args); err != nil {
-		return 2
-	}
-	if sourceRoot == "" || dbPath == "" {
-		fmt.Fprintln(stderr, "atomic code __serve: --source and --db are required")
+	if sourceRoot == "" || explicitDB == "" {
+		fmt.Fprintln(stderr, "atomic code mcp: --daemon requires --source and --db")
 		return 1
 	}
 
@@ -1067,8 +1066,8 @@ func runServe(ctx context.Context, args []string, stderr io.Writer) int {
 		interval = watchInterval
 	}
 
-	if err := codemcp.RunDaemon(ctx, sourceRoot, dbPath, nil, interval); err != nil {
-		fmt.Fprintf(stderr, "atomic code __serve: %v\n", err)
+	if err := codemcp.RunDaemon(ctx, sourceRoot, explicitDB, nil, interval); err != nil {
+		fmt.Fprintf(stderr, "atomic code mcp: %v\n", err)
 		return 1
 	}
 	return 0

--- a/atomic/internal/codeintel/cli/realm.go
+++ b/atomic/internal/codeintel/cli/realm.go
@@ -36,11 +36,13 @@ func RunCodeWithRealm(args []string, projectRoot, claudeMDPath string, stdout, s
 		return 0
 	}
 
-	// __serve is an internal verb spawned by the proxy with explicit --source/--db
-	// flags. Route it directly to RunCode (which dispatches to runServe) before
-	// realm resolution, so the daemon never hits the realm-verb-reject gate
-	// regardless of the process cwd. This is what makes the daemon cwd-independent.
-	if args[0] == "__serve" {
+	// A --daemon invocation of the mcp verb is spawned by DefaultSpawn with
+	// explicit --source/--db flags (GitHub issue #193 — daemon mode folded into
+	// the mcp verb so the spawned argv always names a Cobra-registered command).
+	// Route it directly to RunCode before realm resolution, so the daemon never
+	// hits the realm-verb-reject gate regardless of the process cwd. This is
+	// what makes the daemon cwd-independent.
+	if args[0] == "mcp" && containsFlag(args[1:], "daemon") {
 		return RunCode(args, projectRoot, stdout, stderr, stdin)
 	}
 
@@ -128,15 +130,6 @@ func runRealmMember(args []string, res realm.Resolution, stdout, stderr io.Write
 		return runMCP(ctx, memberAbs, dbPath, args[1:], stderr)
 	}
 
-	// __serve is an internal verb invoked by the proxy subprocess with explicit
-	// --source/--db flags. It must never reach this routing layer (the proxy
-	// spawns it as a top-level `atomic code __serve` command, bypassing realm
-	// dispatch entirely via main.go's special-casing).
-	if verb == "__serve" {
-		fmt.Fprintf(stderr, "atomic code __serve: not available in realm-member scope (internal verb)\n")
-		return 1
-	}
-
 	eng, err := engine.NewWithDBPath(memberAbs, dbPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "atomic code: create engine for %s: %v\n", m.Key, err)
@@ -163,11 +156,6 @@ func runRealmAll(args []string, cwd string, res realm.Resolution, claudeMDPath s
 	case "mcp":
 		// No single target — tell the user to use --repo to pick one.
 		fmt.Fprintf(stderr, "atomic code mcp: not available in realm scope; pass --repo <member> to serve a specific repo\n")
-		return 1
-	case "__serve":
-		// Internal verb spawned by the proxy with explicit --source/--db; should
-		// never reach realm routing (main.go handles it before calling RunCodeWithRealm).
-		fmt.Fprintf(stderr, "atomic code __serve: internal verb not available in realm scope\n")
 		return 1
 	}
 

--- a/atomic/internal/codeintel/mcp/binary_e2e_test.go
+++ b/atomic/internal/codeintel/mcp/binary_e2e_test.go
@@ -1,0 +1,143 @@
+// This file is the one test in the package that runs the shipped atomic
+// binary rather than calling into the package in-process. Everything else in
+// this package structurally cannot see argv assembly through the real Cobra
+// tree, exit-code propagation through main, or whether a spawned subprocess
+// actually binds its socket — exactly the seam GitHub issue #193 hid behind:
+// a green in-process suite while every real `atomic code mcp` auto-start
+// failed with "daemon did not start within 10s".
+//
+// Precedent: atomic/internal/repl/binary_e2e_test.go.
+package mcp_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	codemcp "github.com/damusix/atomic-claude/atomic/internal/codeintel/mcp"
+)
+
+const (
+	// e2eBuildTimeout bounds `go build`. Generous because a cold module cache
+	// links the whole binary (tree-sitter/wazero included); warm it is ~1s.
+	e2eBuildTimeout = 5 * time.Minute
+	// e2eRunTimeout bounds the whole daemon subprocess's lifetime in this test.
+	e2eRunTimeout = 30 * time.Second
+	// e2eSocketWait bounds how long we wait for the daemon to bind its socket
+	// before declaring the spawn broken. Generous relative to a local unix
+	// listen + MkdirAll, which is sub-second in practice.
+	e2eSocketWait = 10 * time.Second
+)
+
+// TestMCPDaemonBinary_StartsAndBindsSocket execs the real atomic binary with
+// exactly the argv DefaultSpawn would produce (via DaemonArgv) and asserts the
+// daemon binds its socket within a bounded window. Before the GitHub issue
+// #193 fix, this argv named an unregistered internal verb: Cobra rejected it
+// with "unknown flag", the process exited immediately, and no socket ever
+// appeared.
+func TestMCPDaemonBinary_StartsAndBindsSocket(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not on PATH: %v", err)
+	}
+
+	bin := buildAtomicBinaryForMCPE2E(t)
+
+	// /tmp-rooted, not t.TempDir(): the socket path is derived from dbPath's
+	// directory (SocketPathFromDB), and t.TempDir() embeds the full test name —
+	// long enough to blow the ~104-108 byte unix sun_path limit on macOS/Linux.
+	srcDir := shortE2ETempDir(t)
+	dbPath := filepath.Join(shortE2ETempDir(t), "atomic.db")
+
+	argv := codemcp.DaemonArgv(srcDir, dbPath, codemcp.WatchOptions{Disable: true})
+
+	ctx, cancel := context.WithTimeout(context.Background(), e2eRunTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, argv...)
+	cmd.Dir = srcDir
+	var out []byte
+	outFile, err := os.CreateTemp(t.TempDir(), "daemon-out")
+	if err != nil {
+		t.Fatalf("create daemon output capture file: %v", err)
+	}
+	defer outFile.Close()
+	cmd.Stdout = outFile
+	cmd.Stderr = outFile
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start daemon subprocess (%v %v): %v", bin, argv, err)
+	}
+	// exited fires once, from the Wait() goroutine below, the moment the
+	// subprocess exits — including the pre-fix RED case where Cobra rejects
+	// the argv and the process exits within milliseconds, well before
+	// e2eSocketWait would otherwise be spent polling a socket that never appears.
+	exited := make(chan *os.ProcessState, 1)
+	go func() {
+		_ = cmd.Wait()
+		exited <- cmd.ProcessState
+	}()
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-exited
+	})
+
+	sockPath := codemcp.SocketPathFromDB(dbPath)
+	deadline := time.Now().Add(e2eSocketWait)
+	for {
+		if codemcp.IsLive(sockPath) {
+			return
+		}
+		select {
+		case state := <-exited:
+			exited <- state // let the cleanup goroutine's <-exited also observe it
+			out, _ = os.ReadFile(outFile.Name())
+			t.Fatalf("daemon subprocess exited (code %d) before binding its socket at %s; output:\n%s",
+				state.ExitCode(), sockPath, out)
+		default:
+		}
+		if time.Now().After(deadline) {
+			out, _ = os.ReadFile(outFile.Name())
+			t.Fatalf("daemon did not bind its socket at %s within %s; output so far:\n%s", sockPath, e2eSocketWait, out)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// shortE2ETempDir returns a short, /tmp-rooted temp dir, mirroring
+// atomic/internal/repl's shortTempDir — t.TempDir() nests the full test name
+// and can exceed the unix sun_path limit for a socket path derived from it.
+func shortE2ETempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "atmc-mcp-e2e")
+	if err != nil {
+		return t.TempDir()
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// buildAtomicBinaryForMCPE2E builds cmd/atomic and returns the path to the
+// binary. Mirrors atomic/internal/repl/binary_e2e_test.go's buildAtomicBinary.
+func buildAtomicBinaryForMCPE2E(t *testing.T) string {
+	t.Helper()
+
+	moduleRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve module root: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "atomic")
+
+	ctx, cancel := context.WithTimeout(context.Background(), e2eBuildTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./cmd/atomic")
+	cmd.Dir = moduleRoot
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cmd/atomic: %v\n%s", err, combined)
+	}
+	return out
+}

--- a/atomic/internal/codeintel/mcp/daemon.go
+++ b/atomic/internal/codeintel/mcp/daemon.go
@@ -187,7 +187,7 @@ type SyncFunc func(ctx context.Context) error
 
 // Daemon is the per-project unix-socket MCP singleton daemon.
 //
-// Use RunDaemon to start it from the `atomic code __serve` internal verb.
+// Use RunDaemon to start it from `atomic code mcp --daemon`.
 // Use NewTestDaemon to construct one with injectable durations for tests.
 type Daemon struct {
 	socketPath string

--- a/atomic/internal/codeintel/mcp/proxy.go
+++ b/atomic/internal/codeintel/mcp/proxy.go
@@ -4,9 +4,9 @@
 // the singleton daemon (flock-guarded) and then bidirectionally pipes
 // stdin↔socket / stdout↔socket.
 //
-// The daemon entry point is RunDaemon, invoked by the internal `atomic code __serve`
-// verb (see code.go). That verb is NOT advertised in /atomic-help; it is called
-// only by the auto-start path.
+// The daemon entry point is RunDaemon, invoked via the same `mcp` verb with
+// --daemon set (see code.go). --daemon is not advertised as a normal workflow
+// flag; it exists for the auto-start path (DefaultSpawn/DaemonArgv) to invoke.
 package mcp
 
 import (
@@ -35,7 +35,7 @@ type WatchOptions struct {
 
 // SpawnFunc is the function called by the proxy to start the daemon when the
 // socket is absent or dead. The real implementation forks a detached
-// `atomic code __serve --source SRC --db DB [--watch-interval T | --no-watch]`
+// `atomic code mcp --daemon --source SRC --db DB [--watch-interval T | --no-watch]`
 // subprocess. Tests inject an in-process stub that starts a goroutine daemon
 // instead.
 //
@@ -44,23 +44,33 @@ type WatchOptions struct {
 // opts controls the sync-poller flags forwarded to the daemon.
 type SpawnFunc func(sourceRoot, dbPath string, opts WatchOptions) error
 
-// DefaultSpawn starts `atomic code __serve --source <sourceRoot> --db <dbPath>`
-// detached (no TTY, stdout/stderr to devnull so the parent can exit immediately).
-// Passing explicit paths makes the daemon cwd-independent: it never re-resolves
-// scope from the process working directory.
+// DaemonArgv builds the argv DefaultSpawn execs to start the daemon: the
+// already-registered `code mcp` verb with --daemon plus the explicit
+// source+db paths (GitHub issue #193 — folding daemon mode into `mcp` instead
+// of a separate internal verb keeps the spawned command permanently
+// Cobra-registered, so it can never again drift out of the command tree).
+// Exported so tests can drive the exact argv DefaultSpawn produces.
+func DaemonArgv(sourceRoot, dbPath string, opts WatchOptions) []string {
+	argv := []string{"code", "mcp", "--daemon", "--source", sourceRoot, "--db", dbPath}
+	if opts.Disable {
+		argv = append(argv, "--no-watch")
+	} else if opts.Interval > 0 {
+		argv = append(argv, "--watch-interval", opts.Interval.String())
+	}
+	return argv
+}
+
+// DefaultSpawn starts `atomic code mcp --daemon --source <sourceRoot> --db
+// <dbPath>` detached (no TTY, stdout/stderr to devnull so the parent can exit
+// immediately). Passing explicit paths makes the daemon cwd-independent: it
+// never re-resolves scope from the process working directory.
 // opts is forwarded as --watch-interval / --no-watch flags to the daemon.
 func DefaultSpawn(sourceRoot, dbPath string, opts WatchOptions) error {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("spawn daemon: locate executable: %w", err)
 	}
-	argv := []string{"code", "__serve", "--source", sourceRoot, "--db", dbPath}
-	if opts.Disable {
-		argv = append(argv, "--no-watch")
-	} else if opts.Interval > 0 {
-		argv = append(argv, "--watch-interval", opts.Interval.String())
-	}
-	cmd := exec.Command(self, argv...)
+	cmd := exec.Command(self, DaemonArgv(sourceRoot, dbPath, opts)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// Detach from the parent's process group so the daemon survives the proxy exit.
 		Setsid: true,

--- a/docs/design/code-mcp-per-repo.md
+++ b/docs/design/code-mcp-per-repo.md
@@ -9,9 +9,9 @@ Reproduced deterministically. Claude Code launches an MCP server with its cwd at
 ```
 atomic --repo /…/taxgentic/gui code mcp        (cwd = /…/taxgentic, not a git repo)
   → proxy resolves --repo gui (ok, no git needed)
-  → spawns:  atomic code __serve gui     (child inherits cwd = /…/taxgentic)
+  → spawns:  atomic code mcp --daemon gui  (child inherits cwd = /…/taxgentic)
   → child re-resolves scope from CWD, not from its path arg:
-       realm.Resolve(/…/taxgentic) = ScopeRealmAll → __serve is in the realm reject set → daemon exits
+       realm.Resolve(/…/taxgentic) = ScopeRealmAll → mcp --daemon is in the realm reject set → daemon exits
        (or, from a plain non-git dir: repoctx.Resolve("") → git rev-parse fails → exit 128)
   → socket never binds → proxy waitLive times out (10s) → "daemon did not start within 10s"
 ```
@@ -39,7 +39,7 @@ Second defect, same area: a realm member has no local index — its graph lives 
 
 ## Root cause (one line)
 
-The daemon (`__serve`) and the `code` dispatch resolve project scope from the **current working directory** instead of trusting the path they were handed; launched from a non-git / realm-root cwd (where `.mcp.json` lives), the spawned daemon dies before binding its socket.
+The daemon (`mcp --daemon`) and the `code` dispatch resolve project scope from the **current working directory** instead of trusting the path they were handed; launched from a non-git / realm-root cwd (where `.mcp.json` lives), the spawned daemon dies before binding its socket.
 
 ## Approaches
 
@@ -47,7 +47,7 @@ The daemon (`__serve`) and the `code` dispatch resolve project scope from the **
 |---|----------|------|------|
 | A | Spawn daemon with explicit (sourceRoot, dbPath); daemon uses `NewWithDBPath`, never consults cwd | cwd-independent; fixes db-location + pollution in one move; no realm-verb-rejection in the daemon | touches proxy spawn + daemon signature + socket path |
 | B | Set `cmd.Dir = <member>` on the spawn so cwd becomes the member | smaller diff | member dir is a git repo but the index is under the realm → still wrong db; still pollutes; fragile |
-| C | Make `--repo`/`__serve` run `realm.Resolve(path)` in the existing dispatch | reuses position-sensing | still routes through the realm-verb-rejection (mcp/__serve rejected in member scope); needs un-rejection anyway |
+| C | Make `--repo`/`mcp --daemon` run `realm.Resolve(path)` in the existing dispatch | reuses position-sensing | still routes through the realm-verb-rejection (mcp rejected in member scope); needs un-rejection anyway |
 
 ## Recommendation
 
@@ -58,7 +58,7 @@ flowchart TD
   P["atomic --repo PATH code mcp (any cwd)"] --> R[realm.Resolve PATH]
   R -->|member| D1[sourceRoot=member, dbPath=realm/.atomic/key.db]
   R -->|standalone repo| D2[sourceRoot=repo, dbPath=repo/.claude/.atomic-index/atomic.db]
-  D1 --> S["spawn __serve --source SRC --db DB (explicit, cwd-independent)"]
+  D1 --> S["spawn mcp --daemon --source SRC --db DB (explicit, cwd-independent)"]
   D2 --> S
   S --> DA[daemon: NewWithDBPath SRC,DB]
   DA --> SK[socket next to DB, not in member source]

--- a/docs/spec/code-intel-surfaces.md
+++ b/docs/spec/code-intel-surfaces.md
@@ -282,3 +282,21 @@ resolvers' existing `Resolve`/`ClaimsReference`.
 framework-extraction seam — the index pipeline ran extract → resolve, skipping
 framework route extraction. The pipeline is now extract → framework-extract →
 resolve.
+
+### 2026-08-10 — `mcp` verb's internal `__serve` sibling folded into `--daemon`
+
+**What changed:** The CP23 entry above (2026-06-06) documents `cli/code.go`
+wiring an internal `__serve` verb to `RunDaemon`; that verb was never
+registered in the Cobra tree, so every real daemon auto-start spawn (which
+execs `atomic code __serve --source ... --db ...`) failed with Cobra's
+"unknown flag" before `RunDaemon` ever ran — invisible in-process because
+CP23's 13 tests all drove `RunDaemon`/`RunProxy` directly, never through the
+real command tree. Daemon mode is now a `--daemon` flag on the already-
+registered `mcp` verb (`atomic code mcp --daemon --source <path> --db
+<path>`); `runServe` is deleted.
+
+**Why:** GitHub issue #193.
+
+**Superseded:** The CP23 entry's "internal `__serve` verb invokes `RunDaemon`"
+clause; the daemon entry point is unchanged (`RunDaemon`), only the verb that
+reaches it changed.

--- a/docs/spec/code-mcp-per-repo.md
+++ b/docs/spec/code-mcp-per-repo.md
@@ -31,7 +31,7 @@ Resolve the db from the explicit path and spawn a cwd-independent daemon that se
 
 | # | Checkpoint | Files/areas | Agent | Est. files | Verifies |
 |---|-----------|--------------|-------|-----------|---------|
-| 1 | Reproduce + fix: cwd-independent daemon serving the explicit db, socket next to the db, no member pollution | `atomic/internal/codeintel/cli/code.go` (`runMCP`, `runServe`), `atomic/internal/codeintel/cli/realm.go` (`--repo`/`__serve` path resolution; the explicit-path single target must not hit the mcp/`__serve` realm reject), `atomic/internal/codeintel/mcp/proxy.go` (spawn explicit source+db, cwd-independent), `atomic/internal/codeintel/mcp/daemon.go` (`RunDaemon` takes source+db, `NewWithDBPath`; `SocketPath`/`LockPath` derive from the db dir), `atomic/cmd/atomic/main.go` (`--repo` resolves member→realm db); new test in `mcp/` or `cli/` | atomic-implementer (feature) | 5–9 | new regression test is RED before the fix, GREEN after: daemon launched with cwd at a non-git dir binds its socket and answers `initialize`; member path → realm db, standalone → local index; member source tree stays clean; repo-mode socket path unchanged |
+| 1 | Reproduce + fix: cwd-independent daemon serving the explicit db, socket next to the db, no member pollution | `atomic/internal/codeintel/cli/code.go` (`runMCP`, including its `--daemon` branch), `atomic/internal/codeintel/cli/realm.go` (`--repo`/`--daemon` path resolution; the explicit-path single target must not hit the mcp realm reject), `atomic/internal/codeintel/mcp/proxy.go` (spawn explicit source+db, cwd-independent), `atomic/internal/codeintel/mcp/daemon.go` (`RunDaemon` takes source+db, `NewWithDBPath`; `SocketPath`/`LockPath` derive from the db dir), `atomic/cmd/atomic/main.go` (`--repo` resolves member→realm db); new test in `mcp/` or `cli/` | atomic-implementer (feature) | 5–9 | new regression test is RED before the fix, GREEN after: daemon launched with cwd at a non-git dir binds its socket and answers `initialize`; member path → realm db, standalone → local index; member source tree stays clean; repo-mode socket path unchanged |
 | 2 | In-daemon periodic self-sync (10s) | `atomic/internal/codeintel/mcp/daemon.go` (poller goroutine on daemon ctx), small poller helper if needed; `cli/code.go` (`--watch-interval`/`--no-watch` flags) | atomic-implementer (feature) | 3–5 | sync fires on a clock-injected interval and stops on ctx cancel (test); named const default 10s asserted by test |
 | 3 | Concurrency + surface | test for 2+ concurrent daemons different repos; `atomic/internal/cliusage/`, `templates/commands/atomic-help.md`, `docs/reference/code-intel.md` for any new mcp flag; `make render` + `make -C atomic bundle` | atomic-implementer (feature) | 4–6 | 2+ daemons different repos, no collision (test); cliusage/help/docs reflect any new flag; render+bundle drift-clean |
 
@@ -43,10 +43,18 @@ Resolve the db from the explicit path and spawn a cwd-independent daemon that se
 | Risk | Likelihood | Mitigation |
 |------|-----------|-----------|
 | Socket-path change breaks existing repo-mode MCP | Medium | Repo-mode (local index) keeps its current socket path; only members move the socket to the db dir under `<realm>/.atomic/`. Test both paths. |
-| Un-rejecting mcp/`__serve` re-introduces ambiguity at a realm root | Low | Only the explicit-path single-target (`--repo`, or the spawned `__serve` with explicit source+db) serves; `code mcp` from a realm-root cwd with no `--repo` has no single target and stays rejected. |
+| Un-rejecting a daemon-mode mcp invocation re-introduces ambiguity at a realm root | Low | Only the explicit-path single-target (`--repo`, or the spawned `mcp --daemon` invocation with explicit source+db) serves; `code mcp` from a realm-root cwd with no `--repo` has no single target and stays rejected. |
 | Self-sync boots a parser pool on every change | Low | Lazy pool (already landed) only boots on a real change; gate the sync on a cheap pending-change check; a no-op tick stays sub-second. |
 | Two daemons race writing the same realm db (member MCP + a future external sync) | Low | One daemon per db; SQLite WAL + busy-timeout already configured. Out of scope to coordinate external writers. |
 
 ## Change log
 
 (empty — spec created 2026-06-22)
+
+### 2026-08-10 — Daemon mode folded into `code mcp --daemon`
+
+**What changed:** The internal `atomic code __serve` verb DefaultSpawn used to exec was never registered as a Cobra subcommand, so the `code` parent's own flag parsing rejected the spawn's `--source`/`--db` flags with "unknown flag" — every real auto-start daemon spawn failed, surfacing only as "daemon did not start within 10s" at the proxy. Daemon mode is now a `--daemon` flag on the already-registered `mcp` verb (`atomic code mcp --daemon --source <path> --db <path>`); `mcp.DaemonArgv` is the single seam both `DefaultSpawn` and its regression tests build the argv through, so the two can no longer drift apart. `runServe` is deleted; `runMCP` gained the `--daemon` branch.
+
+**Why:** GitHub issue #193 — the checkpoint 1 fix this spec originally described worked in-process (tests passed) but never worked as a real spawned subprocess, because the spawned verb was never wired into the Cobra command tree.
+
+**Superseded:** The checkpoint 1 row and the "Un-rejecting mcp/`__serve`" risk row above described an internal `__serve` verb; both now read `--daemon` instead.


### PR DESCRIPTION
`atomic code mcp` could never auto-start its daemon: the proxy spawned the internal `code __serve` verb, which was never registered in the cobra tree, so flag parsing died at the `code` parent before dispatch and the proxy timed out after 10s with the daemon's stderr discarded.

Rather than registering the hidden verb, daemon mode now rides the already-registered `mcp` verb as `--daemon --source --db` — no shadow verb to forget in future cobra migrations. A new test drives the root command with the exact spawn argv, so spawn/cobra-tree drift fails the suite; a real-binary e2e test verifies the spawned daemon binds its socket.

Closes #193
