### PR TITLE
test(repl): deterministic eval-serialization check + plan usage samples

### DIFF
--- a/atomic/internal/doctemplate/templates/design-doc.md
+++ b/atomic/internal/doctemplate/templates/design-doc.md
@@ -19,10 +19,15 @@ rename sections; add sections only when the design genuinely needs them.
      next to what it explains. No quota in either direction: none for a simple change,
      several for a multi-flow or multi-entity design. One-sentence caption above each
      block so non-rendering readers still get it.
-     Pseudocode: a fenced language-neutral pseudocode block is welcome wherever it is
-     the clearest statement of logic — an algorithm, a decision rule, a matching order.
-     Pseudocode communicates the rule, not the implementation: no real signatures,
-     imports, or library calls. -->
+     Pseudocode: a fenced pseudocode block is welcome wherever it is the clearest
+     statement of logic — an algorithm, a decision rule, a matching order.
+     Language-agnostic preferred (no syntax details to parse); a real language
+     (TypeScript, SQL) is fine when it genuinely conveys better, kept illustrative —
+     no real imports or library calls. Pseudocode communicates the rule, not the
+     implementation.
+     Usage sample: when the work ships a surface others call — a library, an API,
+     a CLI — sketch both sides: the implementation shape AND how the consumer uses
+     it (the public call site, the command invocation, the request/response). -->
 
 
 ## Goals / Non-goals

--- a/atomic/internal/embedded/bundle/commands/atomic-plan.md
+++ b/atomic/internal/embedded/bundle/commands/atomic-plan.md
@@ -89,7 +89,8 @@ Design captures things the spec deliberately doesn't:
 - Approaches considered and rejected, with reasoning. Evidence-backed (file:line, signals, prior decisions) where the evidence exists; honest about gaps where it doesn't.
 - Open philosophical / product questions that the spec shouldn't try to answer.
 - Diagrams of conceptual relationships (entities, states, flows) — not call graphs. Use as many as the complexity warrants — flowcharts, ERDs, sequence, state — each placed next to what it explains. No quota in either direction: a diagram earns its place by clarifying something, never by satisfying the template.
-- Pseudocode where it is the clearest statement of logic — an algorithm, a decision rule, a matching order. Language-neutral, fenced, no real signatures or library calls: it communicates the rule, not the implementation. The design doc is the home for pseudocode; the spec stays contract-level.
+- Pseudocode where it is the clearest statement of logic — an algorithm, a decision rule, a matching order. Language-agnostic preferred: the reader should absorb the rule without parsing syntax details. A real language (TypeScript, SQL, ...) is fine when it genuinely conveys better — SQL for relational logic, TS for type shapes — but it stays illustrative: no real imports or library calls. It communicates the rule, not the implementation. The design doc is the home for pseudocode; the spec stays contract-level.
+- When the work ships a surface others call — a library, an API, a CLI — sketch both sides: how it is implemented and how the consumer uses it (the public call site, the command invocation, the request/response). A design that only shows the inside hides the contract that matters most.
 
 The design doc persists by default. Whether it gets cited later is downstream — not a gate. A design doc that captured one feature's thinking still pays for itself by anchoring the spec authoring loop and giving future contributors the "why".
 

--- a/atomic/internal/embedded/manifest.go
+++ b/atomic/internal/embedded/manifest.go
@@ -22,7 +22,7 @@ func Manifest() []Artifact {
 		{Kind: "command", Source: "bundle/commands/_templates/implementer-prompt.md", Target: "commands/_templates/implementer-prompt.md", SHA256: "88821c30f61b773218b90332f2060eec09979515545aaddfcb10081f1e8ce14f"},
 		{Kind: "command", Source: "bundle/commands/_templates/reviewer-prompt.md", Target: "commands/_templates/reviewer-prompt.md", SHA256: "296889105ed096f4afb9239c5931f9b900037d55e676f89bf3023daf5d62ffed"},
 		{Kind: "command", Source: "bundle/commands/atomic-help.md", Target: "commands/atomic-help.md", SHA256: "1c7e53afb742de2f28ebc9bf051c26d1e6fe2eeee23695513446d1e5a6793d57"},
-		{Kind: "command", Source: "bundle/commands/atomic-plan.md", Target: "commands/atomic-plan.md", SHA256: "726aac9549f60fa53a0ddbd64344fdde08133d80617e7a05b5e30405ffe2aa37"},
+		{Kind: "command", Source: "bundle/commands/atomic-plan.md", Target: "commands/atomic-plan.md", SHA256: "ff5ade72a644f82a6ad4461fe69556b1a89023ea633c320c6ed4e95c9dd31e5e"},
 		{Kind: "command", Source: "bundle/commands/autopilot.md", Target: "commands/autopilot.md", SHA256: "870d43fb4ed89bdfea1c2544a0470eefbf1dd5f03301bc075bd923f1efc224d8"},
 		{Kind: "command", Source: "bundle/commands/challenge-swarm.md", Target: "commands/challenge-swarm.md", SHA256: "be8a134582d0557fddbc088f82da43b48a613ea551e1f9b0908821b7cf8af4a9"},
 		{Kind: "command", Source: "bundle/commands/commit.md", Target: "commands/commit.md", SHA256: "fbeb67340badfc2bc68d080dd60b15e7b319b0a4123357643001c32856a3d324"},

--- a/atomic/internal/repl/harness_contract_test.go
+++ b/atomic/internal/repl/harness_contract_test.go
@@ -79,8 +79,8 @@ type harnessCase struct {
 	stateGet         string // reads it back, evaluating to 42
 	resetErrorMarker string // error naming the unbound variable after a reset
 
-	slowEval string // blocks the harness for slowEvalWindow, then yields 'slow-done'
-	fastEval string // returns immediately, evaluating to 2
+	slowEval string // blocks for slowEvalWindow, then binds the marker fastEval reads and yields 'slow-done'
+	fastEval string // computes 42 from slowEval's marker — unbound (an error) unless slowEval completed first
 	wantFast string
 }
 
@@ -335,12 +335,8 @@ func runHarnessConformance(t *testing.T, c harnessCase) {
 	t.Run("concurrent evals serialize", func(t *testing.T) {
 		h := startHarness(t, c, conformanceIdleTimeout)
 
-		type outcome struct {
-			resp     Response
-			finished time.Time
-		}
-		slowDone := make(chan outcome, 1)
-		fastDone := make(chan outcome, 1)
+		slowDone := make(chan Response, 1)
+		fastDone := make(chan Response, 1)
 
 		slowConn := h.dial(t)
 		fastConn := h.dial(t)
@@ -348,7 +344,7 @@ func runHarnessConformance(t *testing.T, c harnessCase) {
 		go func() {
 			slowConn.write(t, Request{V: ProtocolVersion, Op: OpEval, Code: c.slowEval})
 			resp, _ := slowConn.read(t)
-			slowDone <- outcome{resp, time.Now()}
+			slowDone <- resp
 		}()
 
 		// Give the harness time to accept the slow connection and start
@@ -359,23 +355,25 @@ func runHarnessConformance(t *testing.T, c harnessCase) {
 		go func() {
 			fastConn.write(t, Request{V: ProtocolVersion, Op: OpEval, Code: c.fastEval})
 			resp, _ := fastConn.read(t)
-			fastDone <- outcome{resp, time.Now()}
+			fastDone <- resp
 		}()
 
 		slow := waitOutcome(t, slowDone, "slow eval")
 		fast := waitOutcome(t, fastDone, "fast eval")
 
-		assertOK(t, slow.resp)
-		if fast.resp.Error != "" {
-			t.Errorf("second eval errored while another was in flight: %s", fast.resp.Error)
+		assertOK(t, slow)
+		if fast.Error != "" {
+			t.Errorf("second eval errored while another was in flight: %s", fast.Error)
 		}
-		assertOK(t, fast.resp)
-		if fast.resp.Value != c.wantFast {
-			t.Errorf("second eval value = %q, want %q", fast.resp.Value, c.wantFast)
-		}
-		if fast.finished.Before(slow.finished) {
-			t.Errorf("second eval finished at %s, before the first at %s — evals did not serialize",
-				fast.finished.Format(time.StampMilli), slow.finished.Format(time.StampMilli))
+		assertOK(t, fast)
+		// Ordering is proven inside the interpreter: fastEval computes its
+		// value from a marker slowEval binds as its final act, so a harness
+		// that ran them concurrently yields an unbound-name error or a wrong
+		// value here. Comparing client-side time.Now() stamps instead was
+		// flaky — both responses can arrive within the same instant and
+		// goroutine scheduling then decides which stamps first.
+		if fast.Value != c.wantFast {
+			t.Errorf("second eval value = %q, want %q — evals did not serialize", fast.Value, c.wantFast)
 		}
 	})
 

--- a/atomic/internal/repl/harness_node_test.go
+++ b/atomic/internal/repl/harness_node_test.go
@@ -41,9 +41,9 @@ func TestNodeHarness(t *testing.T) {
 		stateGet:         "stateProbe + 1",
 		resetErrorMarker: "ReferenceError",
 
-		slowEval: "(() => { const until = Date.now() + 600; while (Date.now() < until) {} return 'slow-done'; })()",
-		fastEval: "1 + 1",
-		wantFast: "2",
+		slowEval: "(() => { const until = Date.now() + 600; while (Date.now() < until) {} globalThis.slowMarker = 40; return 'slow-done'; })()",
+		fastEval: "slowMarker + 2",
+		wantFast: "42",
 	})
 }
 

--- a/atomic/internal/repl/harness_python_test.go
+++ b/atomic/internal/repl/harness_python_test.go
@@ -42,9 +42,9 @@ func TestPythonHarness(t *testing.T) {
 		stateGet:         "state_probe + 1",
 		resetErrorMarker: "NameError",
 
-		slowEval: "import time\ntime.sleep(0.6)\n'slow-done'",
-		fastEval: "1 + 1",
-		wantFast: "2",
+		slowEval: "import time\ntime.sleep(0.6)\nslow_marker = 40\n'slow-done'",
+		fastEval: "slow_marker + 2",
+		wantFast: "42",
 	})
 }
 

--- a/commands/atomic-plan.md
+++ b/commands/atomic-plan.md
@@ -89,7 +89,8 @@ Design captures things the spec deliberately doesn't:
 - Approaches considered and rejected, with reasoning. Evidence-backed (file:line, signals, prior decisions) where the evidence exists; honest about gaps where it doesn't.
 - Open philosophical / product questions that the spec shouldn't try to answer.
 - Diagrams of conceptual relationships (entities, states, flows) — not call graphs. Use as many as the complexity warrants — flowcharts, ERDs, sequence, state — each placed next to what it explains. No quota in either direction: a diagram earns its place by clarifying something, never by satisfying the template.
-- Pseudocode where it is the clearest statement of logic — an algorithm, a decision rule, a matching order. Language-neutral, fenced, no real signatures or library calls: it communicates the rule, not the implementation. The design doc is the home for pseudocode; the spec stays contract-level.
+- Pseudocode where it is the clearest statement of logic — an algorithm, a decision rule, a matching order. Language-agnostic preferred: the reader should absorb the rule without parsing syntax details. A real language (TypeScript, SQL, ...) is fine when it genuinely conveys better — SQL for relational logic, TS for type shapes — but it stays illustrative: no real imports or library calls. It communicates the rule, not the implementation. The design doc is the home for pseudocode; the spec stays contract-level.
+- When the work ships a surface others call — a library, an API, a CLI — sketch both sides: how it is implemented and how the consumer uses it (the public call site, the command invocation, the request/response). A design that only shows the inside hides the contract that matters most.
 
 The design doc persists by default. Whether it gets cited later is downstream — not a gate. A design doc that captured one feature's thinking still pays for itself by anchoring the spec authoring loop and giving future contributors the "why".
 

--- a/templates/commands/atomic-plan.md
+++ b/templates/commands/atomic-plan.md
@@ -89,7 +89,8 @@ Design captures things the spec deliberately doesn't:
 - Approaches considered and rejected, with reasoning. Evidence-backed (file:line, signals, prior decisions) where the evidence exists; honest about gaps where it doesn't.
 - Open philosophical / product questions that the spec shouldn't try to answer.
 - Diagrams of conceptual relationships (entities, states, flows) — not call graphs. Use as many as the complexity warrants — flowcharts, ERDs, sequence, state — each placed next to what it explains. No quota in either direction: a diagram earns its place by clarifying something, never by satisfying the template.
-- Pseudocode where it is the clearest statement of logic — an algorithm, a decision rule, a matching order. Language-neutral, fenced, no real signatures or library calls: it communicates the rule, not the implementation. The design doc is the home for pseudocode; the spec stays contract-level.
+- Pseudocode where it is the clearest statement of logic — an algorithm, a decision rule, a matching order. Language-agnostic preferred: the reader should absorb the rule without parsing syntax details. A real language (TypeScript, SQL, ...) is fine when it genuinely conveys better — SQL for relational logic, TS for type shapes — but it stays illustrative: no real imports or library calls. It communicates the rule, not the implementation. The design doc is the home for pseudocode; the spec stays contract-level.
+- When the work ships a surface others call — a library, an API, a CLI — sketch both sides: how it is implemented and how the consumer uses it (the public call site, the command invocation, the request/response). A design that only shows the inside hides the contract that matters most.
 
 The design doc persists by default. Whether it gets cited later is downstream — not a gate. A design doc that captured one feature's thinking still pays for itself by anchoring the spec authoring loop and giving future contributors the "why".
 


### PR DESCRIPTION
Two small fixes.

**repl flake** — `concurrent_evals_serialize` failed twice in a row on next (attempt 1 Python, attempt 2 Node): it compared client-side `time.Now()` stamps taken after each socket read, and on loaded CI runners both responses arrive within the same instant, letting goroutine scheduling decide which stamps first (both failures show identical millisecond timestamps). The fast eval now computes `42` from a marker the slow eval binds as its final act — ordering proven inside the interpreter; a non-serializing harness yields an unbound-name error. 15× stress green.

**atomic-plan** — design docs for a surface others call (library/API/CLI) sketch both sides: implementation and a consumer usage sample. Pseudocode stays agnostic-preferred; a real language (TS, SQL) is allowed when it genuinely conveys better.