### PR TITLE
fix(wiki): stamp accepts flags in any arg position

### DIFF
--- a/atomic/internal/wiki/action.go
+++ b/atomic/internal/wiki/action.go
@@ -115,11 +115,24 @@ func wikiStampAction(args []string) int {
 	fs.BoolVar(&knowledge, "knowledge", false, "knowledge page mode: stamp sources: list")
 	fs.StringVar(&sources, "sources", "", "comma-separated sources entries (knowledge mode)")
 
-	if err := fs.Parse(args); err != nil {
-		return 2
+	// Stdlib flag.FlagSet stops parsing at the first non-flag argument, so a
+	// single fs.Parse(args) never consumes flags placed after the positional
+	// <file> argument (issue #158). Re-parse iteratively, peeling off one
+	// positional token at a time, so flags may appear in any position —
+	// before, after, or interspersed with <file>.
+	var positional []string
+	rest := args
+	for {
+		if err := fs.Parse(rest); err != nil {
+			return 2
+		}
+		rest = fs.Args()
+		if len(rest) == 0 {
+			break
+		}
+		positional = append(positional, rest[0])
+		rest = rest[1:]
 	}
-
-	positional := fs.Args()
 	if len(positional) < 1 {
 		fmt.Fprintf(os.Stderr, "Usage: atomic wiki stamp <file> --repo <path>\n")
 		fmt.Fprintf(os.Stderr, "       atomic wiki stamp <file> --root <wiki-root> --cites <ids>\n")

--- a/atomic/internal/wiki/action.go
+++ b/atomic/internal/wiki/action.go
@@ -120,8 +120,24 @@ func wikiStampAction(args []string) int {
 	// <file> argument (issue #158). Re-parse iteratively, peeling off one
 	// positional token at a time, so flags may appear in any position —
 	// before, after, or interspersed with <file>.
+	//
+	// Pre-split at the first bare "--" before the loop so POSIX terminator
+	// semantics hold globally: everything after it is positional, verbatim,
+	// never re-parsed as a flag. (fs.Parse only honors "--" within the call
+	// that consumes it — re-parsing the tail would otherwise treat a flag
+	// placed after "--" as live again.)
+	head := args
+	var tail []string
+	for i, a := range args {
+		if a == "--" {
+			head = args[:i]
+			tail = args[i+1:]
+			break
+		}
+	}
+
 	var positional []string
-	rest := args
+	rest := head
 	for {
 		if err := fs.Parse(rest); err != nil {
 			return 2
@@ -133,6 +149,7 @@ func wikiStampAction(args []string) int {
 		positional = append(positional, rest[0])
 		rest = rest[1:]
 	}
+	positional = append(positional, tail...)
 	if len(positional) < 1 {
 		fmt.Fprintf(os.Stderr, "Usage: atomic wiki stamp <file> --repo <path>\n")
 		fmt.Fprintf(os.Stderr, "       atomic wiki stamp <file> --root <wiki-root> --cites <ids>\n")

--- a/atomic/internal/wiki/action_test.go
+++ b/atomic/internal/wiki/action_test.go
@@ -1,14 +1,17 @@
 package wiki
 
 // action_test.go — CP1 tests for the shared argument scanner hardening
-// (resolveWikiRoot / parseBucketDocArgs) behind `atomic wiki bucket`.
+// (resolveWikiRoot / parseBucketDocArgs) behind `atomic wiki bucket`, plus
+// wikiStampAction's flag/positional argument order handling.
 //
 // Covers: -h/-help/--help yield errUsageRequested and print usage without
 // mutating state (issue #164 — `bucket add -h` used to silently create a
 // bucket named "-h"); an unrecognized single-dash token is rejected with
 // the same parity as an unrecognized double-dash token; parseBucketDocArgs'
 // collapse to delegate at resolveWikiRoot still honors --router in any
-// position.
+// position; wikiStampAction accepts flags before, after, or interspersed
+// with the positional <file> argument, and honors "--" as a global
+// terminator ending flag parsing (issue #158).
 
 import (
 	"bytes"
@@ -400,4 +403,55 @@ func TestWikiStampAction_MissingModeFlagsStillErrors(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("wikiStampAction with no mode flags: exit %d, want 1", code)
 	}
+}
+
+// TestWikiStampAction_TerminatorEndsFlagParsing pins POSIX "--" terminator
+// semantics (issue #158 follow-up): the re-parse loop must honor the first
+// bare "--" globally, not just within the single fs.Parse call that consumes
+// it. Everything after "--" is positional, verbatim, never re-parsed as a
+// flag — so `wiki stamp -- <file> --repo <repo>` must NOT stamp.
+func TestWikiStampAction_TerminatorEndsFlagParsing(t *testing.T) {
+	repoDir := makeStampGitRepo(t)
+
+	t.Run("post-terminator flags are literal, no mode set", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "target.md")
+		if err := os.WriteFile(file, []byte("---\ntitle: x\n---\nbody\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+
+		code := wikiStampAction([]string{"--", file, "--repo", repoDir})
+		if code != 1 {
+			t.Fatalf("wikiStampAction(-- %s --repo %s) = %d, want 1 (--repo after -- must be literal)", file, repoDir, code)
+		}
+
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if strings.Contains(string(data), "reflects_rev:") {
+			t.Errorf("expected no stamp written after literal --repo, got:\n%s", data)
+		}
+	})
+
+	t.Run("flags before terminator still parse, positional after stamps", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "target.md")
+		if err := os.WriteFile(file, []byte("---\ntitle: x\n---\nbody\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+
+		code := wikiStampAction([]string{"--repo", repoDir, "--", file})
+		if code != 0 {
+			t.Fatalf("wikiStampAction(--repo %s -- %s) = %d, want 0", repoDir, file, code)
+		}
+
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if !strings.Contains(string(data), "reflects_rev:") {
+			t.Errorf("expected reflects_rev stamp written, got:\n%s", data)
+		}
+	})
 }

--- a/atomic/internal/wiki/action_test.go
+++ b/atomic/internal/wiki/action_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -260,5 +261,143 @@ func TestBucketVerbs_UnrecognizedSingleDashTokenExits2(t *testing.T) {
 				t.Errorf("wikiAction bucket %s -x: got exit %d, want 2; output: %q", verb, code, out.String())
 			}
 		})
+	}
+}
+
+// ---- wikiStampAction: flag/positional argument order (issue #158) ----
+//
+// Stdlib flag.FlagSet stops parsing at the first non-flag argument, so the
+// documented `atomic wiki stamp <file> --repo <path>` form (flags after the
+// positional) never consumed the trailing flags and fell through to the
+// "supply either --repo ..." error. wikiStampAction must accept flags in any
+// position — flags-first, flags-after-path, and interspersed.
+
+// makeStampGitRepo creates a git repo with one commit and returns its dir.
+func makeStampGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmds := [][]string{
+		{"git", "-C", dir, "init"},
+		{"git", "-C", dir, "config", "user.email", "t@t.com"},
+		{"git", "-C", dir, "config", "user.name", "T"},
+	}
+	for _, c := range cmds {
+		if out, err := exec.Command(c[0], c[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", c, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	addCmds := [][]string{
+		{"git", "-C", dir, "add", "."},
+		{"git", "-C", dir, "commit", "-m", "init"},
+	}
+	for _, c := range addCmds {
+		if out, err := exec.Command(c[0], c[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", c, err, out)
+		}
+	}
+	return dir
+}
+
+// TestWikiStampAction_FlagOrder is a table test over the three stamp modes
+// (summary / concern / knowledge) crossed with three argument orders
+// (flags-first, flags-after-path, interspersed). All nine combinations must
+// exit 0 and actually write the expected frontmatter key.
+func TestWikiStampAction_FlagOrder(t *testing.T) {
+	repoDir := makeStampGitRepo(t)
+
+	knowledgeRoot := t.TempDir()
+	citedSignalsDir := filepath.Join(knowledgeRoot, "cited-repo", ".claude", "project")
+	if err := os.MkdirAll(citedSignalsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(citedSignalsDir, "signals.md"), []byte("signals\n"), 0o644); err != nil {
+		t.Fatalf("write signals.md: %v", err)
+	}
+
+	type modeCase struct {
+		name     string
+		pairs    [][]string // each element is one complete flag unit (name, or name+value) — never split
+		wantKey  string
+		fileName string // must be kebab-case for knowledge mode
+	}
+	modes := []modeCase{
+		{name: "summary", pairs: [][]string{{"--repo", repoDir}}, wantKey: "reflects_rev", fileName: "target.md"},
+		{name: "concern", pairs: [][]string{{"--root", knowledgeRoot}, {"--cites", "cited-repo"}}, wantKey: "reflects", fileName: "target.md"},
+		{name: "knowledge", pairs: [][]string{{"--knowledge"}, {"--sources", "research/notes.md@abc123"}}, wantKey: "sources", fileName: "topic.md"},
+	}
+
+	flatten := func(pairs [][]string) []string {
+		var out []string
+		for _, p := range pairs {
+			out = append(out, p...)
+		}
+		return out
+	}
+
+	orders := []struct {
+		name  string
+		build func(file string, pairs [][]string) []string
+	}{
+		{name: "flags-first", build: func(file string, pairs [][]string) []string {
+			return append(flatten(pairs), file)
+		}},
+		{name: "flags-after-path", build: func(file string, pairs [][]string) []string {
+			return append([]string{file}, flatten(pairs)...)
+		}},
+		{name: "interspersed", build: func(file string, pairs [][]string) []string {
+			// Split at a pair boundary — never inside a flag/value pair,
+			// which would otherwise swallow the positional as the flag's value.
+			mid := len(pairs) / 2
+			out := flatten(pairs[:mid])
+			out = append(out, file)
+			out = append(out, flatten(pairs[mid:])...)
+			return out
+		}},
+	}
+
+	for _, m := range modes {
+		for _, o := range orders {
+			t.Run(m.name+"/"+o.name, func(t *testing.T) {
+				dir := t.TempDir()
+				file := filepath.Join(dir, m.fileName)
+				if err := os.WriteFile(file, []byte("---\ntitle: x\n---\nbody\n"), 0o644); err != nil {
+					t.Fatalf("write %s: %v", file, err)
+				}
+
+				args := o.build(file, m.pairs)
+				code := wikiStampAction(args)
+				if code != 0 {
+					t.Fatalf("wikiStampAction(%v) = %d, want 0", args, code)
+				}
+
+				data, err := os.ReadFile(file)
+				if err != nil {
+					t.Fatalf("read %s: %v", file, err)
+				}
+				if !strings.Contains(string(data), m.wantKey+":") {
+					t.Errorf("expected %q key written to %s; got:\n%s", m.wantKey, file, data)
+				}
+			})
+		}
+	}
+}
+
+// TestWikiStampAction_MissingModeFlagsStillErrors verifies a genuinely
+// missing mode flag (no --repo/--root+--cites/--knowledge+--sources) still
+// produces the existing "supply either" error and exit 1 — the flag/position
+// fix must not mask real usage errors.
+func TestWikiStampAction_MissingModeFlagsStillErrors(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "target.md")
+	if err := os.WriteFile(file, []byte("---\ntitle: x\n---\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", file, err)
+	}
+
+	code := wikiStampAction([]string{file})
+	if code != 1 {
+		t.Fatalf("wikiStampAction with no mode flags: exit %d, want 1", code)
 	}
 }


### PR DESCRIPTION
stdlib `flag` stops at the first positional, so the documented `wiki stamp <file> --repo <path>` form exited 1 claiming the mode flag was absent — every `/refresh-wiki` stamping pass silently no-oped. An iterative re-parse loop now accepts flags before, after, or interspersed with the file argument. A bare `--` still ends flag parsing (the naive loop re-parsed post-terminator tokens as live flags; a pre-split restores POSIX semantics).

Docs needed no change: the flags-after-path form documented in `refresh-wiki.md` becomes valid as written. Sibling of #164 and #170 — same `DisableFlagParsing` per-verb-parser family, different parser.

Closes #158