### PR TITLE
fix(docs-site): override vitepress-plugin-mermaid peer dep so npm ci resolves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,6 +1836,7 @@
             "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -2270,6 +2271,7 @@
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2521,6 +2523,7 @@
             "integrity": "sha512-6CxwrrFRquH7pDXb1mWxudkU9LSfYBMRZutpgddb2o6iwCk7cIRrBhyY3c8SGKcmIKdeMTrGSNg4Bedh2RSF/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tabbable": "^6.4.0"
             }
@@ -2742,6 +2745,7 @@
             "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@braintree/sanitize-url": "^7.1.2",
                 "@iconify/utils": "^3.0.2",
@@ -2947,6 +2951,7 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3403,6 +3408,7 @@
             "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -3478,6 +3484,7 @@
             "integrity": "sha512-Z3VPUpwk/bHYqt1uMVOOK1/4xFiWQov1GNc2FvMdz6kvje4JRXEOngVI9C+bi5jeedMSHiA4dwKkff1NCvbZ9Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docsearch/css": "^4.5.3",
                 "@docsearch/js": "^4.5.3",
@@ -3539,6 +3546,7 @@
             "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.34",
                 "@vue/compiler-sfc": "3.5.34",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,10 @@
         "vitepress": "2.0.0-alpha.17",
         "vitepress-plugin-mermaid": "^2.0.17",
         "vue": "^3.5.27"
+    },
+    "overrides": {
+        "vitepress-plugin-mermaid": {
+            "vitepress": "$vitepress"
+        }
     }
 }


### PR DESCRIPTION
Every docs deploy since the mermaid plugin landed has failed at `npm ci`: `vitepress-plugin-mermaid@2.0.17` pins peer `vitepress@^1.0.0`, the site runs `2.0.0-alpha.17`, and the lockfile was originally generated with `--legacy-peer-deps` — which `npm ci` refuses to replay. The live site is stuck on the last pre-mermaid build, so fenced diagrams render as raw code blocks.

No plugin release supports VitePress 2, so this adds an npm `overrides` entry forcing the plugin's peer to the root vitepress, plus the regenerated lockfile. Verified locally with the exact CI sequence: `npm ci` resolves clean, `vitepress build` completes, diagrams render.

Targets `main` directly because the deploy only triggers on push to `main`.
