### PR TITLE
docs(design): spec and design consolidation

### DIFF
--- a/docs/design/doc-consolidation.md
+++ b/docs/design/doc-consolidation.md
@@ -42,14 +42,15 @@ flowchart LR
 
 
 - Goals:
-    - One file per shipped feature that passes the rebuild test: an agent reading only it, plus the code's language and runtime, reaches the same build.
+    - One living design doc per feature that passes the rebuild test: an agent reading only it, plus the code's language and runtime, reaches the same build.
     - Every retired file recoverable from a lineage table that names the commit which last held the whole family.
     - Design and spec files enter wiki inference with a contracted role, so diagrams and purpose cross into `docs/wiki/<domain>.md` and drift surfaces on every refresh.
     - Family membership walkable by code, not by prose grep.
 - Non-goals:
     - No third documentation surface. `docs/design/`, `docs/spec/`, `docs/wiki/` keep their roles.
     - The wiki does not absorb tradeoffs. A wiki page that argues is a second design doc that goes stale.
-    - No consolidation of work still in flight. A family with an `active` member stays as it is.
+    - No retirement of work in flight. An `active` spec re-parents to the consolidated design doc and continues; only `shipped` specs fold in.
+    - No end-of-life for the feature. The consolidated design doc is a normal design doc that keeps accepting amendments and new child specs.
     - No automatic consolidation. Detection is code; the write is a human-gated verb.
 
 
@@ -82,11 +83,20 @@ C and F.
 
 | File | Owns | Never carries |
 |------|------|---------------|
-| `docs/design/<feature>.md` | Problem, constraints, approaches weighed, the pick and why, decision diagrams, landmines, lineage table | Checkpoint tables, change trees, current-state claims the code can answer |
+| `docs/design/<feature>.md` | Problem, constraints, approaches weighed, the pick and why, decision diagrams, landmines, `## Lineage`, `## Change log` | Checkpoint tables, change trees, current-state claims the code can answer |
 | `docs/wiki/<domain>.md` | What it is now, current-architecture diagrams, code-verified facts | Tradeoffs, decision history |
-| `docs/spec/<feature>.md` | The contract while `status` is `draft` or `active` | Anything once `status: shipped` and the family is consolidated: the file is retired |
+| `docs/spec/<feature>.md` | The contract while `status` is `draft` or `active` | Anything once `status: shipped` and folded: the file is retired |
 
-A new amendment to a consolidated feature starts a fresh spec with `parent:` pointing at the family design doc. The child-of pattern already in use, now machine-readable.
+The consolidated design doc behaves exactly like any other design doc. It accepts amendments under `## Change log` (same entry template as `rules/specs/spec-currency.md`), and new work on the feature starts a fresh child spec with `parent:` pointing at it. Consolidation compacts history; it does not close the feature. A family consolidates as many times as it ships, and every round folds the newly shipped specs into the same file.
+
+Which members fold in on a round:
+
+```
+for each spec in family(root):
+    shipped  -> fold into docs/design/<root>.md, then retire
+    active   -> keep; set parent: docs/design/<root>.md
+    draft    -> keep; set parent: docs/design/<root>.md
+```
 
 ### The rebuild test governs content and length
 
@@ -135,21 +145,22 @@ Backfill of the 143 existing files is scriptable: `type` from the directory, `de
 
 ### Lineage and the freeze SHA
 
-The commit that last held the whole family is the parent of the retirement commit on the landed branch. The path is the durable key: a squash merge discards branch SHAs, a file path does not move.
+Each round has its own freeze: the parent of that round's retirement commit on the landed branch, the last commit that held every file folded in that round. The path is the durable key: a squash merge discards branch SHAs, a file path does not move.
 
 ```markdown
 ## Lineage
 
-Freeze: `a1b2c3d` (parent of the retirement commit). Recover any row with
-`git show a1b2c3d:<path>`, or without the SHA:
+Recover any row with `git show <freeze>:<path>`, or without the SHA:
 `git log -1 --diff-filter=D --format=%H -- <path>` and read its parent.
 
-| Retired file | Contributed | Recover |
-|--------------|-------------|---------|
-| `docs/spec/code-intel-query.md` | query core, part 4/5, appendix K | `git show a1b2c3d:docs/spec/code-intel-query.md` |
+| Round | Freeze | Retired file | Contributed |
+|-------|--------|--------------|-------------|
+| 2026-09-01 | `a1b2c3d` | `docs/spec/code-intel-query.md` | query core, part 4/5, appendix K |
+| 2026-09-01 | `a1b2c3d` | `docs/spec/code-intel-substrate.md` | schema, indexer, pragma order |
+| 2026-11-14 | `e5f6a7b` | `docs/spec/code-intel-package-nodes.md` | package nodes, import edges |
 ```
 
-The N-to-1 form of the spec-currency rename rule: the lineage table is the pointer, no stub files.
+Rows append; nothing is rewritten. The N-to-1 form of the spec-currency rename rule: the lineage table is the pointer, no stub files. The round also lands as a `## Change log` entry on the design doc naming what the fold changed in the body.
 
 ### Design and spec files get a role in wiki inference
 
@@ -167,7 +178,7 @@ Diagram ownership follows the owner-carries, sibling-points rule with one accept
 
 ### Detection is code, the write is gated
 
-`atomic validate spec` (or a `spec families` verb) lists candidates from frontmatter alone: family of three or more files, every member `shipped`, no open follow-up referencing a member, quiet for 30 days. The verb follows the `/git-cleanup` shape: scan, indexed report, the human picks, nothing destructive without confirmation.
+`atomic validate spec` (or a `spec families` verb) lists candidates from frontmatter alone: every spec with `status: shipped` that has not been folded, grouped by family root. No size threshold and no quiet period; a shipped spec is a dead contract the day it ships, and waiting for the rest of the family is what lets hundreds pile up. The report shows the active and draft members beside them so the human sees what re-parents. The verb follows the `/git-cleanup` shape: scan, indexed report, the human picks, nothing destructive without confirmation.
 
 ```mermaid
 flowchart LR
@@ -175,7 +186,7 @@ flowchart LR
     B --> C["writer subagent<br/>retired files + code + wiki page"]
     C --> D["reviewer<br/>every kept decision true in code<br/>every diagram node resolves"]
     D -->|"CHANGES_REQUESTED"| C
-    D -->|"PASS"| E["retire the family<br/>one docs commit"]
+    D -->|"PASS"| E["fold shipped specs, retire them<br/>re-parent active ones<br/>one docs commit"]
     E --> F["wiki writer for the domain<br/>dispatched directly"]
 ```
 
@@ -191,13 +202,14 @@ The last hop is direct because docs-only commits skip the signals gate, so `mark
 
 - `mdparse.IsATXOnly` (`atomic/internal/mdparse/mdparse.go:133`) treats a `---` under a non-empty line as a setext underline. A frontmatter closing fence after `description: x` is exactly that, so `atomic validate spec` fails every frontmattered spec until it strips the block first. `internal/frontmatter` is used by ten packages and not by `validate/spec.go`.
 - The spec template emitted by `atomic template` and `rules/specs/spec-currency.md` must carry the block, or fresh specs ship without it.
+- The design-doc template has no `## Lineage` or `## Change log` section and forbids improvised headers. Both become optional template sections, and the spec-currency rule's amendment discipline extends to design docs that carry a change log.
 - Feature PRs target `next`; record the freeze SHA after the retirement lands, or rely on the path-keyed recovery.
 
 
 ## Open questions
 
 
-- Partial families: `code-intel-engine.md` is an umbrella with two children added 2026-08-08. Proposed rule is consolidate only when every member is `shipped`; confirm that an umbrella with one active child waits.
+- Umbrella specs: `code-intel-engine.md` is `shipped` and carries the appendix A to O that its active children cite by letter. Folding it moves the appendix into the design doc; the children's citations must re-point in the same round, or the appendix gets folded last.
 - `/atomic-plan` lookup order after retirement: family design doc lineage table first, then `docs/spec/`. One line in the command, but it changes what the planner reads first.
 - Verb name: `/consolidate-docs <feature>` is the working name.
 - Whether `status` is stamped by finalize only, or also derived when every checkpoint row is checked, for specs written before stamping existed.

--- a/docs/design/doc-consolidation.md
+++ b/docs/design/doc-consolidation.md
@@ -1,0 +1,203 @@
+---
+type: Design
+description: Retire a shipped spec/design family into one rebuild-record design doc per feature, and give design and spec files a contracted role in wiki inference.
+domain: docs-meta
+status: draft
+---
+
+# Design and spec consolidation
+
+
+## Problem
+
+
+Every non-trivial task leaves a `docs/design/<topic>.md` and a `docs/spec/<topic>.md`. Nothing retires them. Measured on this repo at `cef29d8`:
+
+| Surface | Count | State |
+|---------|-------|-------|
+| `docs/spec/` | 89 files | 11 in the `code-intel-*` family alone, every one shipped; `*-v2` pairs for `sql-dbt-snowflake` and `tsql-lineage-gaps` |
+| `docs/design/` | 54 files | 36 Mermaid blocks across 29 files |
+| `docs/wiki/` | 13 pages | 20 Mermaid blocks; `code-intel.md` has 2 where its design family has 6 |
+| Family links | 13 files | Prose only: `Parent spec:`, `Child of`, `Umbrella:`, `Continues` |
+| Frontmatter on design or spec | 0 of 143 | Every file opens on a bare `# H1` |
+
+Three failures compound:
+
+- A feature's contract is spread over N specs that drifted from each other and from the code. A reader reconstructs the current design by diffing them; a subagent cannot.
+- The design docs hold the diagrams and the tradeoffs, and the wiki never sees them. The repo pipeline in `context/skills/atomic-wiki/references/repo.md` lists design and spec files in the scan, leaves their inclusion to the inferrer's discretion at Step 3, and binds the writer at Step 4 to "every sentence verifiable by reading a source file". A design doc states intent, not fact, so the only legal use is a link row, which is what `docs/wiki/code-intel.md` carries: five spec links, no diagram, no rationale. Step 5 tells the reviewer to catch "contradictions between a spec and its implementation" and never supplies the spec.
+- Spec-versus-code drift is invisible until someone reads both.
+
+Where each document kind sits today. The dotted edge is the one the pipeline assumes and never provides.
+
+```mermaid
+flowchart LR
+    D["docs/design/*.md<br/>why, tradeoffs, diagrams"] --> S["docs/spec/*.md<br/>contract, checkpoints"]
+    S --> C["code"]
+    C --> W["docs/wiki/&lt;domain&gt;.md<br/>current state"]
+    D -.->|"discretionary, link rows only"| W
+```
+
+
+## Goals / Non-goals
+
+
+- Goals:
+    - One file per shipped feature that passes the rebuild test: an agent reading only it, plus the code's language and runtime, reaches the same build.
+    - Every retired file recoverable from a lineage table that names the commit which last held the whole family.
+    - Design and spec files enter wiki inference with a contracted role, so diagrams and purpose cross into `docs/wiki/<domain>.md` and drift surfaces on every refresh.
+    - Family membership walkable by code, not by prose grep.
+- Non-goals:
+    - No third documentation surface. `docs/design/`, `docs/spec/`, `docs/wiki/` keep their roles.
+    - The wiki does not absorb tradeoffs. A wiki page that argues is a second design doc that goes stale.
+    - No consolidation of work still in flight. A family with an `active` member stays as it is.
+    - No automatic consolidation. Detection is code; the write is a human-gated verb.
+
+
+## Approaches
+
+
+Where the consolidated feature record lives:
+
+| # | Approach | Pros | Cons |
+|---|----------|------|------|
+| A | Merge the family into one `docs/spec/<feature>.md` | Keeps the spec as the single contract | `rules/specs/spec-currency.md` forbids history in a spec body; a spec for shipped work is a dead contract, the code and wiki are truth |
+| B | New surface, `docs/features/<feature>.md` | Clean slate | Third place for the same facts; the design/spec split already encodes current versus history |
+| C | Consolidate into `docs/design/<feature>.md`, retire the specs, wiki stays current truth | Design already owns why, rejected approaches, and diagrams; zero new surfaces; spec retirement leaves no hole because `docs/wiki/<domain>.md` already carries current state | Backfill cost on the first families; `/atomic-plan` must look at the family design doc before grepping `docs/spec/` |
+
+How code identifies a family:
+
+| # | Approach | Pros | Cons |
+|---|----------|------|------|
+| D | New `feature:` frontmatter key | Direct | Invents a convention: 0 of 143 files carry any frontmatter today |
+| E | Filename prefix plus prose markers | Zero migration | `atomic-*` covers bus, serve, doctor, validate, repl, and where; prose grep is fragile |
+| F | Extend the OKF keys the wiki and bucket docs already use (`type`, `description`, `status`) with `domain` and `parent`; family is the `parent` chain | Same vocabulary as `docs/wiki/*.md` and the bucket six-key contract; `atomic serve` markdown search reads frontmatter as raw text, so specs become searchable for free | 143-file backfill, mostly scriptable; `atomic validate spec` must learn to skip the block |
+
+
+## Recommendation
+
+
+C and F.
+
+### Document roles after consolidation
+
+| File | Owns | Never carries |
+|------|------|---------------|
+| `docs/design/<feature>.md` | Problem, constraints, approaches weighed, the pick and why, decision diagrams, landmines, lineage table | Checkpoint tables, change trees, current-state claims the code can answer |
+| `docs/wiki/<domain>.md` | What it is now, current-architecture diagrams, code-verified facts | Tradeoffs, decision history |
+| `docs/spec/<feature>.md` | The contract while `status` is `draft` or `active` | Anything once `status: shipped` and the family is consolidated: the file is retired |
+
+A new amendment to a consolidated feature starts a fresh spec with `parent:` pointing at the family design doc. The child-of pattern already in use, now machine-readable.
+
+### The rebuild test governs content and length
+
+A paragraph that would not change what gets built goes. Visuals carry the shape; prose carries only what a diagram cannot: why an order is fixed, which hop surprises, what the failure looks like.
+
+| In | Out |
+|----|-----|
+| Problem, constraints, who reaches it | Checkpoint tables, iteration notes |
+| Approaches weighed, tradeoffs, the pick and why | Change trees, outlines |
+| Architecture, data-model, and flow diagrams | Per-spec Goal and Non-goals boilerplate |
+| Every `Correction:` and `Superseded:` entry from the retired change logs, and closed follow-ups: the mistakes a rebuild would repeat | Dates, SHAs, agent chatter |
+| Lineage table and freeze SHA | |
+
+Spec change logs are the richest rebuild input. The writer mines them, not only the design bodies.
+
+### Consolidation is reconciliation, not summarization
+
+Summarizing drifted specs consolidates the drift. The writer reads the retired files and the code; every decision kept must still be true in the code. A contradiction becomes a finding for the human, never a blended sentence. The same rule applies to pictures: a design diagram drew intent, and every node in a promoted diagram must resolve to a real symbol or file. `atomic code search <node>` checks that mechanically. No match means redraw or drop, never copy.
+
+### Frontmatter contract
+
+Extends the OKF keys already on `docs/wiki/*.md` and bucket docs. No new vocabulary beyond `domain` and `parent`.
+
+```yaml
+---
+type: Spec                                   # Design | Spec
+description: <the H1, as a sentence>
+domain: code-intel                           # wiki domain slug; roots only, children inherit
+parent: docs/spec/sql-language-support.md    # absent on a family root
+status: shipped                              # draft | active | shipped
+---
+```
+
+Family resolution:
+
+```
+root(f)   = f if f.parent is absent, else root(f.parent)
+family(r) = r plus every file whose root is r
+domain(f) = root(f).domain
+target(r) = docs/design/<basename of r>.md
+```
+
+`status: shipped` and the shipping SHA are stamped by the finalize phase of `/subagent-implementation` and `/autopilot`, so no prose parsing decides whether a file is done.
+
+Backfill of the 143 existing files is scriptable: `type` from the directory, `description` from the H1, `parent` from the 13 prose markers, `domain` from the filename prefix with a hand table for the 12 `atomic-*` files, `status: shipped` by default with the handful in flight flipped by hand.
+
+### Lineage and the freeze SHA
+
+The commit that last held the whole family is the parent of the retirement commit on the landed branch. The path is the durable key: a squash merge discards branch SHAs, a file path does not move.
+
+```markdown
+## Lineage
+
+Freeze: `a1b2c3d` (parent of the retirement commit). Recover any row with
+`git show a1b2c3d:<path>`, or without the SHA:
+`git log -1 --diff-filter=D --format=%H -- <path>` and read its parent.
+
+| Retired file | Contributed | Recover |
+|--------------|-------------|---------|
+| `docs/spec/code-intel-query.md` | query core, part 4/5, appendix K | `git show a1b2c3d:docs/spec/code-intel-query.md` |
+```
+
+The N-to-1 form of the spec-currency rename rule: the lineage table is the pointer, no stub files.
+
+### Design and spec files get a role in wiki inference
+
+Three edits to `context/skills/atomic-wiki/references/repo.md` and the writer and reviewer prompts:
+
+| Step | Today | After |
+|------|-------|-------|
+| 3 partition | "the docs that describe them", discretionary | `docs/design/*` and `docs/spec/*` join the domain named by `domain:` (filename prefix as fallback) |
+| 4 writer | facts only; design is unusable | Code is the source for facts. Design is the source for purpose (`## What it does` opens on it), vocabulary, and diagrams that pass the code check. Spec is read for vocabulary while `status != shipped`, never cited as current state |
+| 5 reviewer | assumes specs were read | A design or spec claim the code contradicts becomes a Step 6b Concern row |
+
+The reviewer edit makes `/refresh-wiki` the drift detector and the consolidation verb the drift resolver. Same signal, no new scanning.
+
+Diagram ownership follows the owner-carries, sibling-points rule with one accepted duplication: the wiki owns current-architecture diagrams, the design owns decision diagrams (before and after, rejected topologies), and the design embeds the architecture diagram too because a link to a picture is worse than the picture.
+
+### Detection is code, the write is gated
+
+`atomic validate spec` (or a `spec families` verb) lists candidates from frontmatter alone: family of three or more files, every member `shipped`, no open follow-up referencing a member, quiet for 30 days. The verb follows the `/git-cleanup` shape: scan, indexed report, the human picks, nothing destructive without confirmation.
+
+```mermaid
+flowchart LR
+    A["atomic validate spec<br/>candidate families"] --> B["human picks one"]
+    B --> C["writer subagent<br/>retired files + code + wiki page"]
+    C --> D["reviewer<br/>every kept decision true in code<br/>every diagram node resolves"]
+    D -->|"CHANGES_REQUESTED"| C
+    D -->|"PASS"| E["retire the family<br/>one docs commit"]
+    E --> F["wiki writer for the domain<br/>dispatched directly"]
+```
+
+The last hop is direct because docs-only commits skip the signals gate, so `mark-dirty` would not fire.
+
+### Delivery order
+
+1. Frontmatter contract, backfill script, finalize stamping, validator fix. Makes the graph visible; candidates are invisible without it.
+2. Wiki pipeline roles (Steps 3, 4, 5).
+3. The consolidation verb.
+
+### Landmines
+
+- `mdparse.IsATXOnly` (`atomic/internal/mdparse/mdparse.go:133`) treats a `---` under a non-empty line as a setext underline. A frontmatter closing fence after `description: x` is exactly that, so `atomic validate spec` fails every frontmattered spec until it strips the block first. `internal/frontmatter` is used by ten packages and not by `validate/spec.go`.
+- The spec template emitted by `atomic template` and `rules/specs/spec-currency.md` must carry the block, or fresh specs ship without it.
+- Feature PRs target `next`; record the freeze SHA after the retirement lands, or rely on the path-keyed recovery.
+
+
+## Open questions
+
+
+- Partial families: `code-intel-engine.md` is an umbrella with two children added 2026-08-08. Proposed rule is consolidate only when every member is `shipped`; confirm that an umbrella with one active child waits.
+- `/atomic-plan` lookup order after retirement: family design doc lineage table first, then `docs/spec/`. One line in the command, but it changes what the planner reads first.
+- Verb name: `/consolidate-docs <feature>` is the working name.
+- Whether `status` is stamped by finalize only, or also derived when every checkpoint row is checked, for specs written before stamping existed.

--- a/docs/spec/doc-frontmatter.md
+++ b/docs/spec/doc-frontmatter.md
@@ -1,0 +1,197 @@
+# Doc frontmatter contract
+
+
+## Goal
+
+
+Every `docs/design/<topic>.md` and `docs/spec/<topic>.md` carries a YAML frontmatter block
+(`type`, `description`, `domain`, `parent`, `status`) that code can parse, so family
+membership and shipped state are queryable without prose grep. `atomic validate spec` enforces
+the block; a migration step backfills every pre-existing file in this repo.
+
+
+## Non-goals
+
+
+- No `feature:` key. Family membership is the `parent` chain, resolved at read time.
+- No changes to `docs/wiki/*.md` or bucket-doc frontmatter; both already carry their own
+  contract and are untouched here.
+- No wiki-pipeline role for design/spec files (`context/skills/atomic-wiki/references/repo.md`
+  Steps 3/4/5). That is phase 2 of `docs/design/doc-consolidation.md`.
+- No consolidation verb, lineage table, or spec retirement. That is phase 3.
+- No automatic `status` derivation from checkpoint completion. `status: shipped` is stamped
+  only by the finalize phase of `/subagent-implementation` and `/autopilot`.
+
+
+## Success criteria
+
+
+- [ ] `atomic template spec` emits a file whose frontmatter block carries `type: Spec` and
+      passes `atomic validate spec` with no other content beyond placeholders; `atomic
+      template design-doc` emits a file whose block carries `type: Design`, has no
+      `## Checkpoints` section, and passes the same command.
+- [ ] `atomic validate spec` discovers `docs/spec/*.md` and `docs/design/*.md`, strips the
+      leading frontmatter block from every discovered file before any rule runs, and offsets
+      every finding's `Line` to match the un-stripped file. S0, S1, S5, and S6 run only on a
+      file whose `type` is `Spec`; the frontmatter rule runs on every discovered file
+      regardless of `type`.
+- [ ] A design or spec file missing the block, missing a required key, carrying an invalid
+      `type`/`status` enum value, or whose `parent` does not resolve to an existing file fails
+      validation. `domain` is required only on a family root, a file with no `parent` key; a
+      file that carries `parent` may omit `domain` and inherits it at read time.
+- [ ] `atomic migrate --repo <path>` at target `1.3.0` adds the block to every
+      `docs/design/*.md` and `docs/spec/*.md` file that lacks one; a file that already has the
+      block is left byte-identical; re-running the step is a no-op.
+- [ ] The finalize phase of `/subagent-implementation` and `/autopilot` stamps
+      `status: shipped` and `shipped_sha` on every spec the task shipped, in the same commit as
+      the signals refresh.
+- [ ] Every pre-existing `docs/design/*.md` and `docs/spec/*.md` file in this repo carries the block; files whose `domain` could not be
+      derived are hand-filled, none left without the rest of the block.
+
+
+## Approach
+
+
+Approach F: extend the OKF keys already on `docs/wiki/*.md` and bucket docs (`type`,
+`description`, `status`) with `domain` and `parent`; see `docs/design/doc-consolidation.md`.
+
+
+## Change tree
+
+
+```
+atomic/internal/doctemplate/templates/
+├── spec.md ................................ M  (frontmatter block)
+├── design-doc.md ........................... M  (frontmatter block)
+atomic/internal/doctemplate/doctemplate_test.go  M  (block round-trips through Get)
+atomic/internal/validate/
+├── spec.go ................................. M  (discover both dirs, strip+offset,
+│                                                  type-gated S0/S1/S5/S6, new S7 rule)
+├── dispatch.go .............................. M  (isSpecPath and the whole-repo glob cover
+│                                                  docs/design/*.md too)
+├── spec_test.go ............................ M  (S7 cases, type-gating cases)
+└── testdata/spec/
+    ├── pass/S7/ ............................. A  (valid block fixtures, Spec and Design)
+    ├── pass/design-no-checkpoints/ .......... A  (type: Design, no Checkpoints, passes whole)
+    └── fail/S7/ .............................. A  (missing/invalid/broken-parent fixtures)
+atomic/internal/migrate/
+├── steps_docfrontmatter.go ................. A  (1.3.0 backfill step)
+└── steps_docfrontmatter_test.go ............. A  (idempotence + derivation cases)
+context/rules/specs/spec-currency.md ......... M  (frontmatter contract paragraph)
+context/commands/
+├── atomic-plan.md .......................... M  (planner fills the block)
+├── subagent-implementation.md .............. M  (finalize stamps status+sha)
+└── autopilot.md ............................ M  (finalize stamps status+sha)
+docs/reference/conventions.md ................ M  (frontmatter contract row)
+docs/design/*.md (every file) ................ M  (backfill)
+docs/spec/*.md (every file) .................. M  (backfill)
+```
+
+
+## Outline
+
+
+```
+atomic/internal/validate/spec.go
+  discovery glob — docs/spec/*.md and docs/design/*.md under the repo root
+  RunSpecRules — strips the leading frontmatter block before any rule, offsets every
+    finding's Line by the block's line height, always runs S7, runs S0/S1/S5/S6 only
+    when the block's type is Spec
+  S7 — frontmatter-block rule: presence, required keys, type/status enum values,
+    domain required only when parent is absent, parent path resolution
+
+atomic/internal/validate/dispatch.go
+  isSpecPath — matches docs/spec/*.md and docs/design/*.md
+  runWholeRepo — globs both directories before calling RunSpecRules
+
+atomic/internal/migrate/steps_docfrontmatter.go
+  docFrontmatterBackfill — 1.3.0 repo-scope step registered via init()
+    deriveType — docs/design -> Design, docs/spec -> Spec
+    deriveDescription — H1 text as a sentence
+    deriveParent — prose markers (Parent spec:, Child of, Umbrella:, Continues, Grandparent)
+    deriveDomain — filename prefix table; unresolved atomic-* left for hand fill
+
+context/commands/subagent-implementation.md
+  Phase 3 finalize — stamp status: shipped + shipped_sha on shipped specs, same commit
+    as the signals refresh
+
+context/commands/autopilot.md
+  Phase 4 — same stamping step
+
+context/rules/specs/spec-currency.md
+  Frontmatter contract — the five keys, enum values, domain required only on family roots
+
+docs/reference/conventions.md
+  Doc frontmatter — human-facing description of the block and its keys
+```
+
+
+## Flows
+
+
+**Flow: validating a frontmattered spec or design doc**
+
+1. `atomic validate spec` with no path discovers `docs/spec/*.md` and `docs/design/*.md`
+   under the repo root; given an explicit path of either kind, it validates that file alone
+2. for each discovered file, `RunSpecRules` parses a leading frontmatter block via
+   `frontmatter.Parse`; the block's line height is recorded and the remaining body is what
+   any further rule runs against
+3. S7 checks the parsed block: `type`, `description`, `status` present with valid values;
+   `domain` is required only when `parent` is absent; a `parent` value must resolve to an
+   existing file on disk
+4. when the block's `type` is `Spec`, S0, S1, S5, and S6 also run against the stripped body;
+   a `Design`-typed file, which carries no `## Checkpoints` section, skips them and is judged
+   on S7 alone
+5. every finding's `Line` is offset by the stripped block height before being returned, so
+   it still points at the right line in the original file
+
+**Flow: repo backfill migration**
+
+1. `atomic migrate --repo <path>` runs at target `1.3.0`
+2. the step globs `docs/design/*.md` and `docs/spec/*.md` under the repo root
+3. for each file, `frontmatter.Parse` runs first; a file that already returns a non-nil
+   `meta` is left untouched
+4. otherwise: `type` from the containing directory, `description` from the H1, `parent` from
+   the first matching prose marker, `domain` from the filename-prefix table; `status:
+   shipped` by default
+5. `frontmatter.Emit` writes the block back; a file whose `domain` could not be derived is
+   written without that key and its path is collected into the step's summary output
+
+**Flow: finalize stamping**
+
+1. `/subagent-implementation` Phase 3 (or `/autopilot` Phase 4) reaches the signals-refresh
+   step after the implementation loop's checkpoints are all green
+2. for every `docs/spec/*.md` file the task's change set touched, the step parses its
+   frontmatter, sets `status: shipped` and `shipped_sha` to the commit about to be made, and
+   emits the file back, the same parse -> mutate -> emit shape as `wiki/stamp.go`'s
+   `updateFrontmatterKey`
+3. the stamped files are staged into the same `chore(signals)` commit as the refresh, not a
+   separate commit
+
+
+## Checkpoints
+
+
+| # | Checkpoint | Files/areas | Agent | Est. files | Verifies |
+|---|------------|-------------|-------|------------|----------|
+| 1 | Frontmatter block on both templates; planner and spec-currency instruct filling it | `atomic/internal/doctemplate/templates/spec.md`, `design-doc.md`, `doctemplate_test.go`, `context/rules/specs/spec-currency.md`, `context/commands/atomic-plan.md` | atomic-implementer (mode: feature) | ~5 | `atomic template spec` / `atomic template design-doc` output carries the block; `doctemplate_test.go` asserts it round-trips |
+| 2 | Validator discovers `docs/spec/*.md` and `docs/design/*.md`, strips the block before any rule with line offset, gates S0/S1/S5/S6 to `type: Spec`, and adds S7 for presence/keys/enums/domain-conditional/parent | `atomic/internal/validate/spec.go`, `dispatch.go`, `spec_test.go` (inline fixtures gain the block; the golden test against `docs/spec/atomic-validate.md` keeps asserting zero FAILs), `docs/spec/atomic-validate.md` (gains the block here, ahead of the backfill, so the golden test stays green), `testdata/spec/pass/S7/`, `testdata/spec/pass/design-no-checkpoints/`, `testdata/spec/fail/S7/` | atomic-implementer (mode: feature) | ~7 | `go test ./internal/validate/...` green; a frontmattered spec no longer fails S0/S1; a `type: Design` fixture with no `## Checkpoints` passes; S7 fails on missing block, bad enum, dangling parent |
+| 3 | Backfill migration step at `1.3.0`, idempotent, derives the five keys | `atomic/internal/migrate/steps_docfrontmatter.go`, `steps_docfrontmatter_test.go` | atomic-implementer (mode: feature) | ~2 | `go test ./internal/migrate/...` green; running the step twice on the same tree produces no second diff |
+| 4 | Finalize phase stamps `status: shipped` + `shipped_sha` in the signals-refresh commit | `context/commands/subagent-implementation.md`, `context/commands/autopilot.md` | atomic-implementer (mode: surgical) | 2 | both commands describe the stamping step landing in the same commit as `chore(signals)`; `make -C atomic bundle` clean |
+| 5 | Backfill every pre-existing spec and design file in this repo; hand-fill ambiguous `atomic-*` domains; document the contract | `docs/spec/*.md`, `docs/design/*.md`, `docs/reference/conventions.md` | atomic-implementer (mode: feature) | every spec and design file plus 1 | `atomic validate spec` reports 0 S7 FAILs across `docs/spec/` and `docs/design/`; every backfilled file's `domain` set or listed as a known gap in the commit message |
+
+
+## Risks
+
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| `mdparse.IsATXOnly` treats a frontmatter closing `---` under `description: x` as a Setext underline, failing S0 on every frontmattered spec | high | strip the block before any `mdparse` call, not just before S0, in checkpoint 2 |
+| Prose-marker parent derivation (`Parent spec:`, `Child of`, ...) misparses a file whose prose uses one of those phrases outside a family reference | med | the migration step lists every derived `parent` value in its summary output for a human skim before the backfill commit lands |
+| The backfill touches every spec and design file in one PR, inflating the diff and colliding with any spec mid-edit on another branch | med | run the backfill last (checkpoint 5), after validator and migration land, so it is a single mechanical commit reviewable by diff shape alone |
+| Domain derivation table misses an `atomic-*` prefix not yet catalogued | low | files with an undetermined domain keep the rest of the block and are surfaced in the step's summary, never silently dropped |
+
+
+## Change log
+
+<!-- Populated on first amendment after the spec is approved. Do not log drafting/refinement turns. -->


### PR DESCRIPTION
Shipped spec families drift apart and the wiki pipeline never reads design docs, so diagrams and rationale stay buried in `docs/design/`.

Records the agreed direction before a spec is derived: retire a shipped family into one rebuild-record `docs/design/<feature>.md` with a lineage table and freeze SHA, extend the OKF frontmatter (`type`/`description`/`status` plus `domain`/`parent`) to design and spec files, and give both a contracted role in wiki inference so diagrams cross to the wiki and drift surfaces on refresh.

Design only. Open questions at the bottom of the doc; next step is `/atomic-plan` for the phase-1 spec.