### PR TITLE
feat(marketing): scripted atomic serve feature-tour recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ atomic/internal/codeintel/tsbinding/src/
 # before-hook, so no shipped binary depends on it being committed.
 atomic/internal/embedded/bundle/
 atomic/internal/embedded/manifest.go
+
+# demo video recordings (marketing/demo/run.mjs)
+marketing/demo/out/

--- a/atomic/internal/serve/frontend/dist/app.css
+++ b/atomic/internal/serve/frontend/dist/app.css
@@ -2786,18 +2786,23 @@ body.mode-graph-view #code-cy {
 }
 
 .search-tab {
-    padding: 6px 14px;
-    font-size: 13px;
-    color: var(--ink-faint);
-    text-decoration: none;
+    margin-bottom: -1px;
+    padding: 6px 14px 8px;
+    border: 0;
     border-bottom: 2px solid transparent;
-    transition: color .12s;
+    background: transparent;
+    color: var(--ink-faint);
+    font-family: var(--sans);
+    font-size: 13px;
+    cursor: pointer;
+    transition: color .12s, border-color .12s;
 }
 
 .search-tab:hover { color: var(--ink); }
 
-.search-tab.active {
+.search-tab[data-selected] {
     color: var(--amber);
+    font-weight: 600;
     border-bottom-color: var(--amber);
 }
 

--- a/atomic/internal/serve/frontend/public/app.css
+++ b/atomic/internal/serve/frontend/public/app.css
@@ -2786,18 +2786,23 @@ body.mode-graph-view #code-cy {
 }
 
 .search-tab {
-    padding: 6px 14px;
-    font-size: 13px;
-    color: var(--ink-faint);
-    text-decoration: none;
+    margin-bottom: -1px;
+    padding: 6px 14px 8px;
+    border: 0;
     border-bottom: 2px solid transparent;
-    transition: color .12s;
+    background: transparent;
+    color: var(--ink-faint);
+    font-family: var(--sans);
+    font-size: 13px;
+    cursor: pointer;
+    transition: color .12s, border-color .12s;
 }
 
 .search-tab:hover { color: var(--ink); }
 
-.search-tab.active {
+.search-tab[data-selected] {
     color: var(--amber);
+    font-weight: 600;
     border-bottom-color: var(--amber);
 }
 

--- a/marketing/demo/README.md
+++ b/marketing/demo/README.md
@@ -1,22 +1,27 @@
 # atomic serve feature tour
 
-Records a narrated-by-title-card walkthrough of `atomic serve` as one 1080p mp4: wiki docs, SQL schema, the message bus with two live Claude agents, plans, and the network graph. Everything runs headless; nothing is captured by hand.
+Records a title-carded walkthrough of `atomic serve` as one 1080p mp4, one scene per surface. Everything runs headless; nothing is captured by hand. Scenes are recorded independently and stitched, so a new or re-shot scene never costs a full re-run.
 
 ## Run
 
 ```sh
-marketing/demo/prep.sh                 # once: build bin/atomic, index the realm, seed a bundle, stop the bus daemon
-node marketing/demo/run.mjs            # full tour -> marketing/demo/out/demo.mp4
-```
-
-Subsets and a server you already started:
-
-```sh
-node marketing/demo/run.mjs --scene docs,graph         # per-scene webm in out/, no concat
-node marketing/demo/run.mjs --url http://127.0.0.1:4500 --scene chat
+marketing/demo/prep.sh                       # once: build bin/atomic, index the realm, seed a bundle, stop the bus daemon
+node marketing/demo/run.mjs                  # record whatever is missing from out/scenes/, stitch out/demo.mp4
+node marketing/demo/run.mjs --scene docs,search,external   # re-shoot only these, keep the rest, re-stitch
+node marketing/demo/run.mjs --force          # re-shoot everything
+node marketing/demo/run.mjs --stitch         # just re-concatenate
+node marketing/demo/run.mjs --url http://127.0.0.1:4500 --scene chat   # drive a server you started
 ```
 
 Refresh the wiki first if the pages look stale: `/refresh-wiki` in a Claude session at the realm root. That is the one preparation step `prep.sh` cannot do.
+
+## Adding a scene
+
+1. Create `scenes/<name>.mjs` exporting `{ name, run(page, { base, root }) }`; use the `overlay.mjs` helpers for every interaction.
+2. Import it in `scenes/index.mjs` and place it in `SCENES` — that array is the tour order.
+3. `node marketing/demo/run.mjs` records only the new one and re-stitches.
+
+Optional scene fields: `viewport` (default 1920x1080), `speed` (playback multiplier applied in normalize), `tapes` + `room` (VHS terminals composed to the right of the browser), `warm(page, ctx)` (runs first in a throwaway page of the same browser context whose video is discarded — the graph scene uses it to fill the layout cache so the recorded page opens already settled).
 
 ## Pipeline
 
@@ -25,22 +30,27 @@ prep.sh            bin/atomic, atomic code index, scratchpad bundle, bus stop
   |
 run.mjs            spawns bin/atomic serve --port 4317 in DEMO_ROOT
   |
-  +-- per scene    Playwright context with recordVideo -> out/NN-<scene>.webm
+  +-- per scene    [warm page]  ->  recorded page  ->  out/raw/<scene>.webm
   |                  overlay.mjs: title card, fake cursor, eased pointer travel
   |
   +-- chat scene   + two VHS tapes in parallel (tapes/agent-a.tape, agent-b.tape)
   |                  ffmpeg hstack: browser 1280px | terminals 640px stacked
   |
-  +-- concat       ffmpeg: every scene -> 1920x1080 H.264 30fps -> out/demo.mp4
+  +-- normalize    out/scenes/<scene>.mp4   1920x1080 H.264 30fps, speed applied, 0.4s head trim
+  |
+  +-- stitch       out/demo.mp4  every present scene in SCENES order (missing ones are listed)
 ```
 
 | Scene | Route | What it shows |
 |-------|-------|---------------|
-| docs | `/` -> member wiki | rendered page, rail Links tab (filter, kind chips), follow a link, rail Graph tab |
+| docs | `/` | Browse drawer tree, a member wiki page, rail Links tab (filter, kind chips), rail Graph tab, follow a link |
+| search | `⌘K` | one query across md / code / plans; a code hit opens the code modal: find-in-file, callers, one hop, Back; View all results |
 | schema | `/code/schema?member=` | filter to a table, source modal, "Written by" and "Read by" openers |
-| chat | `/bus` | open `atomic-demo`, two Sonnet agents join from terminals and greet each other, browser greets both |
+| chat | `/bus` | open `atomic-demo`, two Sonnet agents join from terminals and greet each other, browser greets both (2x) |
 | plans | `/plans?member=` | filter, spec, scratchpad BRIEF/STATE, design, version picker |
-| graph | `/graph` | docs graph settle, shift-hover preview, shift-drag, search, code graph for a member |
+| external | `/external` | outbound URLs by domain, citing pages, first seen |
+| graph | `/graph` | docs graph already settled: shift-hover preview, ctrl-click pin, click opens page, search; same on the code graph ending in the code modal |
+| about | About panel | version, bus rooms, wiki/index health, closing card |
 
 ## Knobs
 
@@ -49,18 +59,22 @@ All optional, read from the environment.
 | Variable | Default | Used by |
 |----------|---------|---------|
 | `DEMO_ROOT` | `~/projects/noorm` | directory served; a realm root or a repo |
+| `DEMO_DOCS_MEMBER` | `monorepo` | docs scene |
+| `DEMO_SEARCH_QUERY` | `change` | search scene |
 | `DEMO_PLAN_MEMBER`, `DEMO_PLAN_SLUG` | `monorepo`, `config-access-roles` | plans scene and `prep.sh` bundle seed |
 | `DEMO_SCHEMA_MEMBER`, `DEMO_SCHEMA_TABLE` | `monorepo`, `Milestone` | schema scene |
 | `DEMO_GRAPH_MEMBER` | `monorepo` | code graph member |
-| `DEMO_SETTLE_MS` | `40000` | graph settle budget |
+| `DEMO_SETTLE_MS` | `60000` | graph settle budget (warm-up only; the recorded page replays from cache) |
 
 The bus room name is fixed at `atomic-demo` in both tapes and `scenes/chat.mjs`; change all three together. Before the chat scene the runner closes that room, stops the daemon, and deletes `~/.atomic/rooms/atomic-demo.log` so old traffic never appears. No other room is touched.
 
 ## What bites
 
-- Playwright never draws the OS pointer. `lib/overlay.mjs` injects a cursor that follows real `mousemove` events, so use its `click`/`glide`/`type` helpers rather than `locator.click()`, or the recording shows things happening with no hand.
-- Graph nodes are GPU-picked inside a canvas. Positions come from `window.GraphCore.debugState()`; hover and drag are Shift-gated. Settle is ~5-10 s with GPU; under software rendering it can exceed the budget, in which case the scene records a still-moving layout.
-- The tapes run a real `claude --model sonnet` with `--strict-mcp-config` and only `Bash(atomic bus:*)` + `Monitor` allowed. Output is nondeterministic; re-run the chat scene alone if an agent rambles. Inherited `CLAUDE_CODE_*` variables are unset in the tape's hidden preamble so a session launched from inside Claude Code does not carry its parent's banners.
+- A scene that throws stops the run with the scene name, keeps `out/raw/<scene>.webm`, and writes `out/raw/<scene>.failed.png`. Fix, then `--scene <name>`.
+- Playwright never draws the OS pointer. `lib/overlay.mjs` injects a cursor that follows real `mousemove` events, so use its `click`/`glide`/`type` helpers rather than `locator.click()`, or the recording shows things happening with no hand. `click` is a single `mouse.click` on purpose: a held press lets outside-pointerdown dismissers (the search palette) unmount the target before mouseup.
+- Search palette rows are Ark combobox options, `[role="option"][data-value^="md:|code:"]`, and switching source clears the query, so the scene retypes it each time.
+- Graph nodes are GPU-picked inside a canvas. Positions come from `window.GraphCore.debugState()`; hover is Shift-gated, pin is a real Control keydown + click. The layout cache key is the data fingerprint (plus member for code), so `warm()` must visit the same views the scene records.
+- The tapes run a real `claude --model sonnet` with `--strict-mcp-config` and only `Bash(atomic bus:*)` + `Monitor` allowed. Output is nondeterministic; re-run `--scene chat` if an agent rambles. Inherited `CLAUDE_CODE_*` variables are unset in the tape's hidden preamble so a session launched from inside Claude Code does not carry its parent's banners.
 - Bus member names carry the realm prefix (`noorm-agent-a`). The browser reads the roster and addresses whatever is there; the tapes tell each agent to find its peer by suffix.
 - `prep.sh` seeds one scratchpad bundle (`atomic scratchpad new <slug> --purpose implement`) inside the plan member so the Plans scene has BRIEF/STATE to show. It is gitignored in that repo and left in place.
 - `recordVideo.size` must equal the viewport or Playwright letterboxes. The chat scene is 1280x1080 on purpose; everything else is 1920x1080.

--- a/marketing/demo/README.md
+++ b/marketing/demo/README.md
@@ -1,0 +1,70 @@
+# atomic serve feature tour
+
+Records a narrated-by-title-card walkthrough of `atomic serve` as one 1080p mp4: wiki docs, SQL schema, the message bus with two live Claude agents, plans, and the network graph. Everything runs headless; nothing is captured by hand.
+
+## Run
+
+```sh
+marketing/demo/prep.sh                 # once: build bin/atomic, index the realm, seed a bundle, stop the bus daemon
+node marketing/demo/run.mjs            # full tour -> marketing/demo/out/demo.mp4
+```
+
+Subsets and a server you already started:
+
+```sh
+node marketing/demo/run.mjs --scene docs,graph         # per-scene webm in out/, no concat
+node marketing/demo/run.mjs --url http://127.0.0.1:4500 --scene chat
+```
+
+Refresh the wiki first if the pages look stale: `/refresh-wiki` in a Claude session at the realm root. That is the one preparation step `prep.sh` cannot do.
+
+## Pipeline
+
+```
+prep.sh            bin/atomic, atomic code index, scratchpad bundle, bus stop
+  |
+run.mjs            spawns bin/atomic serve --port 4317 in DEMO_ROOT
+  |
+  +-- per scene    Playwright context with recordVideo -> out/NN-<scene>.webm
+  |                  overlay.mjs: title card, fake cursor, eased pointer travel
+  |
+  +-- chat scene   + two VHS tapes in parallel (tapes/agent-a.tape, agent-b.tape)
+  |                  ffmpeg hstack: browser 1280px | terminals 640px stacked
+  |
+  +-- concat       ffmpeg: every scene -> 1920x1080 H.264 30fps -> out/demo.mp4
+```
+
+| Scene | Route | What it shows |
+|-------|-------|---------------|
+| docs | `/` -> member wiki | rendered page, rail Links tab (filter, kind chips), follow a link, rail Graph tab |
+| schema | `/code/schema?member=` | filter to a table, source modal, "Written by" and "Read by" openers |
+| chat | `/bus` | open `atomic-demo`, two Sonnet agents join from terminals and greet each other, browser greets both |
+| plans | `/plans?member=` | filter, spec, scratchpad BRIEF/STATE, design, version picker |
+| graph | `/graph` | docs graph settle, shift-hover preview, shift-drag, search, code graph for a member |
+
+## Knobs
+
+All optional, read from the environment.
+
+| Variable | Default | Used by |
+|----------|---------|---------|
+| `DEMO_ROOT` | `~/projects/noorm` | directory served; a realm root or a repo |
+| `DEMO_PLAN_MEMBER`, `DEMO_PLAN_SLUG` | `monorepo`, `config-access-roles` | plans scene and `prep.sh` bundle seed |
+| `DEMO_SCHEMA_MEMBER`, `DEMO_SCHEMA_TABLE` | `monorepo`, `Milestone` | schema scene |
+| `DEMO_GRAPH_MEMBER` | `monorepo` | code graph member |
+| `DEMO_SETTLE_MS` | `40000` | graph settle budget |
+
+The bus room name is fixed at `atomic-demo` in both tapes and `scenes/chat.mjs`; change all three together. Before the chat scene the runner closes that room, stops the daemon, and deletes `~/.atomic/rooms/atomic-demo.log` so old traffic never appears. No other room is touched.
+
+## What bites
+
+- Playwright never draws the OS pointer. `lib/overlay.mjs` injects a cursor that follows real `mousemove` events, so use its `click`/`glide`/`type` helpers rather than `locator.click()`, or the recording shows things happening with no hand.
+- Graph nodes are GPU-picked inside a canvas. Positions come from `window.GraphCore.debugState()`; hover and drag are Shift-gated. Settle is ~5-10 s with GPU; under software rendering it can exceed the budget, in which case the scene records a still-moving layout.
+- The tapes run a real `claude --model sonnet` with `--strict-mcp-config` and only `Bash(atomic bus:*)` + `Monitor` allowed. Output is nondeterministic; re-run the chat scene alone if an agent rambles. Inherited `CLAUDE_CODE_*` variables are unset in the tape's hidden preamble so a session launched from inside Claude Code does not carry its parent's banners.
+- Bus member names carry the realm prefix (`noorm-agent-a`). The browser reads the roster and addresses whatever is there; the tapes tell each agent to find its peer by suffix.
+- `prep.sh` seeds one scratchpad bundle (`atomic scratchpad new <slug> --purpose implement`) inside the plan member so the Plans scene has BRIEF/STATE to show. It is gitignored in that repo and left in place.
+- `recordVideo.size` must equal the viewport or Playwright letterboxes. The chat scene is 1280x1080 on purpose; everything else is 1920x1080.
+
+## Requirements
+
+`npm ci` at the repo root (Playwright 1.61 with a cached Chromium), `brew install vhs ffmpeg`, the JetBrains Mono font for the tapes, and a `claude` on PATH for the chat scene.

--- a/marketing/demo/lib/overlay.mjs
+++ b/marketing/demo/lib/overlay.mjs
@@ -75,7 +75,7 @@ export async function install(page) {
   await page.addInitScript(INIT);
 }
 
-export async function title(page, { kicker = '', heading, sub = '', hold = 1800 }) {
+export async function title(page, { kicker = '', heading, sub = '', hold = 1500 }) {
   await page.evaluate(INIT);
   await page.evaluate(([k, h, s]) => window.__demo.title(k, h, s), [kicker, heading, sub]);
   await page.waitForTimeout(hold);
@@ -85,7 +85,7 @@ export async function title(page, { kicker = '', heading, sub = '', hold = 1800 
 
 // Human-paced pointer travel. Playwright's mouse.move with steps interpolates
 // linearly; an ease curve reads as a hand, not a teleport.
-export async function glide(page, locator, { steps = 28, settle = 350 } = {}) {
+export async function glide(page, locator, { steps = 24, settle = 220 } = {}) {
   await locator.scrollIntoViewIfNeeded();
   const box = await locator.boundingBox();
   if (!box) throw new Error('glide: target has no bounding box');
@@ -100,18 +100,19 @@ export async function glide(page, locator, { steps = 28, settle = 350 } = {}) {
   await page.waitForTimeout(settle);
 }
 
+// Down and up in one go: a held press lets outside-pointerdown dismissers
+// (the search palette) unmount the target before the click completes.
 export async function click(page, locator, opts = {}) {
   await glide(page, locator, opts);
-  await page.mouse.down();
-  await page.waitForTimeout(70);
-  await page.mouse.up();
-  await page.waitForTimeout(opts.after ?? 900);
+  const { x, y } = page.__demoPos;
+  await page.mouse.click(x, y);
+  await page.waitForTimeout(opts.after ?? 650);
 }
 
-export async function type(page, locator, text, { delay = 70, after = 900 } = {}) {
+export async function type(page, locator, text, { delay = 60, after = 700 } = {}) {
   await click(page, locator, { after: 250 });
   await page.keyboard.type(text, { delay });
   await page.waitForTimeout(after);
 }
 
-export const beat = (page, ms = 1400) => page.waitForTimeout(ms);
+export const beat = (page, ms = 1000) => page.waitForTimeout(ms);

--- a/marketing/demo/lib/overlay.mjs
+++ b/marketing/demo/lib/overlay.mjs
@@ -1,0 +1,117 @@
+// Injected into every recorded page. Playwright's video never draws the OS
+// pointer, so the cursor is a DOM element that follows the real mousemove
+// events page.mouse.* fires. The title card is a DOM overlay for the same
+// reason: keeping it inside the page means every scene is one webm with no
+// post-hoc drawtext pass.
+
+const INIT = `
+(() => {
+  const go = () => {
+  if (window.__demo) return;
+  const cur = document.createElement('div');
+  cur.id = '__demo-cursor';
+  Object.assign(cur.style, {
+    position: 'fixed', left: '0', top: '0', width: '22px', height: '22px',
+    zIndex: '2147483646', pointerEvents: 'none',
+    transform: 'translate(-4px,-2px)', transition: 'transform 60ms linear',
+    background: 'url("data:image/svg+xml;utf8,' + encodeURIComponent(
+      '<svg xmlns=\\'http://www.w3.org/2000/svg\\' viewBox=\\'0 0 24 24\\'>' +
+      '<path d=\\'M5 3l14 8.5-6.2 1.4L16 20l-2.3 1-3.2-7.2L5 18z\\' fill=\\'white\\' stroke=\\'black\\' stroke-width=\\'1.6\\' stroke-linejoin=\\'round\\'/></svg>'
+    ) + '") no-repeat',
+  });
+  document.documentElement.appendChild(cur);
+  const ring = document.createElement('div');
+  ring.id = '__demo-ring';
+  Object.assign(ring.style, {
+    position: 'fixed', left: '0', top: '0', width: '36px', height: '36px',
+    zIndex: '2147483645', pointerEvents: 'none', borderRadius: '50%',
+    border: '3px solid #f5c451', opacity: '0', transform: 'translate(-18px,-18px) scale(0.4)',
+  });
+  document.documentElement.appendChild(ring);
+  let x = 0, y = 0;
+  window.addEventListener('mousemove', e => {
+    x = e.clientX; y = e.clientY;
+    cur.style.transform = 'translate(' + (x - 4) + 'px,' + (y - 2) + 'px)';
+  }, true);
+  window.addEventListener('mousedown', () => {
+    ring.style.transition = 'none';
+    ring.style.opacity = '0.9';
+    ring.style.transform = 'translate(' + (x - 18) + 'px,' + (y - 18) + 'px) scale(0.4)';
+    requestAnimationFrame(() => {
+      ring.style.transition = 'opacity 450ms ease-out, transform 450ms ease-out';
+      ring.style.opacity = '0';
+      ring.style.transform = 'translate(' + (x - 18) + 'px,' + (y - 18) + 'px) scale(1.6)';
+    });
+  }, true);
+
+  const card = document.createElement('div');
+  card.id = '__demo-title';
+  Object.assign(card.style, {
+    position: 'fixed', inset: '0', zIndex: '2147483647', display: 'flex',
+    flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+    background: 'rgba(12,12,14,0.92)', color: '#f3f0e8', opacity: '0',
+    pointerEvents: 'none', transition: 'opacity 420ms ease',
+    fontFamily: 'Inter, -apple-system, Helvetica, sans-serif',
+  });
+  card.innerHTML = '<div id="__demo-kicker" style="font-size:22px;letter-spacing:0.22em;text-transform:uppercase;opacity:0.6;margin-bottom:18px"></div>'
+    + '<div id="__demo-h" style="font-size:72px;font-weight:650;letter-spacing:-0.02em"></div>'
+    + '<div id="__demo-sub" style="font-size:28px;opacity:0.75;margin-top:22px;max-width:900px;text-align:center;line-height:1.35"></div>';
+  document.documentElement.appendChild(card);
+  window.__demo = {
+    title(kicker, h, sub) {
+      card.querySelector('#__demo-kicker').textContent = kicker || '';
+      card.querySelector('#__demo-h').textContent = h || '';
+      card.querySelector('#__demo-sub').textContent = sub || '';
+      card.style.opacity = '1';
+    },
+    untitle() { card.style.opacity = '0'; },
+  };
+  };
+  if (document.documentElement) go(); else document.addEventListener('DOMContentLoaded', go);
+})();
+`;
+
+export async function install(page) {
+  await page.addInitScript(INIT);
+}
+
+export async function title(page, { kicker = '', heading, sub = '', hold = 1800 }) {
+  await page.evaluate(INIT);
+  await page.evaluate(([k, h, s]) => window.__demo.title(k, h, s), [kicker, heading, sub]);
+  await page.waitForTimeout(hold);
+  await page.evaluate(() => window.__demo.untitle());
+  await page.waitForTimeout(500);
+}
+
+// Human-paced pointer travel. Playwright's mouse.move with steps interpolates
+// linearly; an ease curve reads as a hand, not a teleport.
+export async function glide(page, locator, { steps = 28, settle = 350 } = {}) {
+  await locator.scrollIntoViewIfNeeded();
+  const box = await locator.boundingBox();
+  if (!box) throw new Error('glide: target has no bounding box');
+  const tx = box.x + box.width / 2, ty = box.y + box.height / 2;
+  const from = page.__demoPos || { x: 40, y: 40 };
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps, e = 1 - Math.pow(1 - t, 3);
+    await page.mouse.move(from.x + (tx - from.x) * e, from.y + (ty - from.y) * e);
+    await page.waitForTimeout(12);
+  }
+  page.__demoPos = { x: tx, y: ty };
+  await page.waitForTimeout(settle);
+}
+
+export async function click(page, locator, opts = {}) {
+  await glide(page, locator, opts);
+  await page.mouse.down();
+  await page.waitForTimeout(70);
+  await page.mouse.up();
+  await page.waitForTimeout(opts.after ?? 900);
+}
+
+export async function type(page, locator, text, { delay = 70, after = 900 } = {}) {
+  await click(page, locator, { after: 250 });
+  await page.keyboard.type(text, { delay });
+  await page.waitForTimeout(after);
+}
+
+export const beat = (page, ms = 1400) => page.waitForTimeout(ms);

--- a/marketing/demo/prep.sh
+++ b/marketing/demo/prep.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# One-time preparation of the realm the demo records against. Idempotent.
+#
+#   marketing/demo/prep.sh [<realm-root>]      default: $DEMO_ROOT, else ~/projects/noorm
+#
+# What it does, and why each step is here rather than in run.mjs:
+#   1. Builds bin/atomic from this checkout — the tour must show the code on
+#      the branch you are on, not whatever `atomic` is on PATH.
+#   2. Indexes every member (`atomic code index` fans out from a realm root)
+#      so the schema and code-graph scenes have data. Incremental; cheap on
+#      re-run.
+#   3. Seeds one scratchpad bundle on the plan the Plans scene opens, so the
+#      scratchpad column has something to show. Gitignored, inside the member.
+#   4. Stops any running bus daemon so the chat scene starts with an empty
+#      roster instead of members left over from earlier sessions.
+#
+# Not done here: refreshing the wiki. That is /refresh-wiki in a Claude
+# session at the realm root — run it first if the wiki pages look stale.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+ROOT="${1:-${DEMO_ROOT:-$HOME/projects/noorm}}"
+PLAN_MEMBER="${DEMO_PLAN_MEMBER:-monorepo}"
+PLAN_SLUG="${DEMO_PLAN_SLUG:-config-access-roles}"
+
+echo "== build"
+make -C "$REPO/atomic" build >/dev/null
+BIN="$REPO/bin/atomic"
+
+echo "== index $ROOT"
+(cd "$ROOT" && "$BIN" code index)
+
+echo "== seed bundle $PLAN_MEMBER/$PLAN_SLUG"
+if [ ! -f "$ROOT/$PLAN_MEMBER/.claude/.scratchpad/$PLAN_SLUG/meta.toml" ]; then
+  (cd "$ROOT/$PLAN_MEMBER" && "$BIN" scratchpad new "$PLAN_SLUG" --purpose implement)
+else
+  echo "already present"
+fi
+
+echo "== bus daemon"
+"$BIN" bus stop || true
+
+echo
+echo "ready: node $HERE/run.mjs --root $ROOT"

--- a/marketing/demo/run.mjs
+++ b/marketing/demo/run.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Records the atomic serve feature tour as one video.
+//
+//   node marketing/demo/run.mjs                       full tour against $DEMO_ROOT
+//   node marketing/demo/run.mjs --scene docs,schema   a subset, no concat
+//   node marketing/demo/run.mjs --url http://127.0.0.1:4500   drive a server you started
+//
+// Flags
+//   --root <dir>      directory to serve (default: env DEMO_ROOT, else ~/projects/noorm)
+//   --bin <path>      atomic binary (default: bin/atomic relative to the repo root)
+//   --url <base>      skip spawning; drive an already-running instance
+//   --port <n>        port for the spawned server (default 4317)
+//   --scene <a,b,c>   run only these scenes, in this order (default: all)
+//   --no-concat       leave per-scene files in out/, skip the final mp4
+//   --keep            don't delete per-scene intermediates after concat
+//
+// Each scene is one Playwright browser context with recordVideo, so its webm
+// is self-contained: title card, interactions, outro beat. The chat scene
+// additionally spawns two VHS tapes in parallel and composes the three
+// recordings side by side. ffmpeg then transcodes every scene to a common
+// 1920x1080 H.264 stream and concatenates.
+//
+// Requires: node_modules/playwright (npm ci at repo root), a cached Chromium,
+// vhs and ffmpeg on PATH (brew install vhs ffmpeg).
+
+import { chromium } from 'playwright';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdirSync, renameSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { install } from './lib/overlay.mjs';
+import { SCENES } from './scenes/index.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, '..', '..');
+const OUT = join(HERE, 'out');
+
+const args = parseArgs(process.argv.slice(2));
+const root = args.root ?? process.env.DEMO_ROOT ?? join(homedir(), 'projects', 'noorm');
+const bin = args.bin ?? join(REPO, 'bin', 'atomic');
+const port = Number(args.port ?? 4317);
+const only = args.scene ? args.scene.split(',').map(s => s.trim()) : null;
+const concat = !args['no-concat'] && !only;
+
+mkdirSync(OUT, { recursive: true });
+
+let server = null;
+let base = args.url;
+if (!base) {
+  if (!existsSync(bin)) fail(`no binary at ${bin} — run: make -C atomic build`);
+  base = `http://127.0.0.1:${port}`;
+  server = spawn(bin, ['serve', '--port', String(port)], { cwd: root, stdio: ['ignore', 'pipe', 'pipe'] });
+  server.stderr.on('data', d => process.stderr.write(`[serve] ${d}`));
+  await waitFor(`${base}/api/status`, 15000);
+  console.log(`serving ${root} at ${base}`);
+}
+
+const browser = await chromium.launch({
+  args: ['--ignore-gpu-blocklist', '--enable-gpu-rasterization', '--force-device-scale-factor=1'],
+});
+
+const produced = [];
+try {
+  const list = only ? only.map(n => SCENES.find(s => s.name === n) ?? fail(`unknown scene ${n}`)) : SCENES;
+  for (const [i, scene] of list.entries()) {
+    const idx = String(i + 1).padStart(2, '0');
+    console.log(`▶ ${idx} ${scene.name}`);
+    const file = await record(scene, idx);
+    produced.push(file);
+    console.log(`  ✓ ${file}`);
+  }
+} finally {
+  await browser.close();
+  server?.kill('SIGTERM');
+}
+
+if (concat) {
+  const final = join(OUT, 'demo.mp4');
+  concatenate(produced, final);
+  if (!args.keep) produced.forEach(f => rmSync(f, { force: true }));
+  console.log(`\n${final}`);
+}
+
+async function record(scene, idx) {
+  const viewport = scene.viewport ?? { width: 1920, height: 1080 };
+  const ctx = await browser.newContext({
+    viewport,
+    recordVideo: { dir: OUT, size: viewport },
+    colorScheme: 'dark',
+  });
+  const page = await ctx.newPage();
+  await install(page);
+  page.on('pageerror', e => console.warn(`  [pageerror] ${e.message}`));
+
+  if (scene.tapes) resetRoom(scene.room);
+  const side = scene.tapes ? runTapes(scene.tapes) : null;
+  try {
+    await scene.run(page, { base, root, idx });
+  } finally {
+    const raw = await page.video().path();
+    await ctx.close();
+    const webm = join(OUT, `${idx}-${scene.name}.webm`);
+    renameSync(raw, webm);
+    if (side) {
+      const tapes = await side;
+      const composed = join(OUT, `${idx}-${scene.name}.composed.mp4`);
+      compose(webm, tapes, composed, viewport);
+      rmSync(webm, { force: true });
+      return composed;
+    }
+    return webm;
+  }
+}
+
+// The room log under ~/.atomic/rooms/ outlives daemon restarts and room
+// closes, and the roster in bus.json rehydrates members from earlier runs.
+// Both would put last week's traffic in the recording, so the demo's own
+// room is dropped, the daemon stopped, and its log removed. Only the demo
+// room is touched.
+function resetRoom(room) {
+  if (!room) return;
+  spawnSync(bin, ['bus', 'close', room], { stdio: 'ignore' });
+  spawnSync(bin, ['bus', 'stop'], { stdio: 'ignore' });
+  rmSync(join(homedir(), '.atomic', 'rooms', `${room}.log`), { force: true });
+}
+
+function runTapes(tapes) {
+  return Promise.all(tapes.map(t => new Promise((res, rej) => {
+    const tape = join(HERE, 'tapes', t);
+    const out = join(OUT, t.replace(/\.tape$/, '.mp4'));
+    const p = spawn('vhs', [tape], {
+      cwd: HERE,
+      env: { ...process.env, DEMO_BIN: bin, DEMO_ROOT: root, DEMO_OUT: OUT },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    p.on('exit', c => c === 0 ? res(out) : rej(new Error(`vhs ${t} exited ${c}`)));
+  })));
+}
+
+// browser | (tape A over tape B), all cut to the shortest input, onto a
+// 1920x1080 canvas so the concat step sees one stream shape.
+function compose(webm, tapes, out, viewport) {
+  const termW = 1920 - viewport.width;
+  const termH = Math.floor(1080 / tapes.length);
+  const inputs = [webm, ...tapes].flatMap(f => ['-i', f]);
+  const scaled = tapes.map((_, i) => `[${i + 1}:v]scale=${termW}:${termH}:force_original_aspect_ratio=decrease,pad=${termW}:${termH}:(ow-iw)/2:(oh-ih)/2:color=#0c0c0e,fps=30[t${i}]`);
+  const stack = tapes.length > 1 ? `${tapes.map((_, i) => `[t${i}]`).join('')}vstack=inputs=${tapes.length}[term]` : `[t0]copy[term]`;
+  const filter = [
+    `[0:v]scale=${viewport.width}:1080:force_original_aspect_ratio=decrease,pad=${viewport.width}:1080:(ow-iw)/2:(oh-ih)/2:color=#0c0c0e,fps=30[web]`,
+    ...scaled, stack,
+    `[web][term]hstack=inputs=2[v]`,
+  ].join(';');
+  ffmpeg(['-y', ...inputs, '-filter_complex', filter, '-map', '[v]', '-shortest', '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '18', '-preset', 'medium', out]);
+}
+
+function concatenate(files, out) {
+  const norm = files.map((f, i) => {
+    const o = join(OUT, `_n${i}.mp4`);
+    ffmpeg(['-y', '-i', f, '-vf', 'scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=#0c0c0e,fps=30,format=yuv420p', '-c:v', 'libx264', '-crf', '18', '-preset', 'medium', '-an', o]);
+    return o;
+  });
+  const list = join(OUT, '_concat.txt');
+  writeFileSync(list, norm.map(f => `file '${f}'`).join('\n') + '\n');
+  ffmpeg(['-y', '-f', 'concat', '-safe', '0', '-i', list, '-c', 'copy', out]);
+  norm.forEach(f => rmSync(f, { force: true }));
+  rmSync(list, { force: true });
+}
+
+function ffmpeg(argv) {
+  const r = spawnSync('ffmpeg', ['-hide_banner', '-loglevel', 'error', ...argv], { stdio: 'inherit' });
+  if (r.status !== 0) fail(`ffmpeg failed: ffmpeg ${argv.join(' ')}`);
+}
+
+async function waitFor(url, ms) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    try { if ((await fetch(url)).ok) return; } catch {}
+    await new Promise(r => setTimeout(r, 200));
+  }
+  fail(`server at ${url} did not answer within ${ms}ms`);
+}
+
+function parseArgs(argv) {
+  const o = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const k = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) o[k] = true; else { o[k] = next; i++; }
+  }
+  return o;
+}
+
+function fail(msg) { console.error(msg); process.exit(1); }

--- a/marketing/demo/run.mjs
+++ b/marketing/demo/run.mjs
@@ -1,24 +1,30 @@
 #!/usr/bin/env node
-// Records the atomic serve feature tour as one video.
+// Records the atomic serve feature tour as one video, one scene at a time.
 //
-//   node marketing/demo/run.mjs                       full tour against $DEMO_ROOT
-//   node marketing/demo/run.mjs --scene docs,schema   a subset, no concat
-//   node marketing/demo/run.mjs --url http://127.0.0.1:4500   drive a server you started
+//   node marketing/demo/run.mjs                  record scenes missing from out/scenes/, then stitch
+//   node marketing/demo/run.mjs --scene search   re-record just these scenes, then stitch
+//   node marketing/demo/run.mjs --force          re-record everything
+//   node marketing/demo/run.mjs --stitch         only concatenate what is already in out/scenes/
 //
 // Flags
 //   --root <dir>      directory to serve (default: env DEMO_ROOT, else ~/projects/noorm)
 //   --bin <path>      atomic binary (default: bin/atomic relative to the repo root)
 //   --url <base>      skip spawning; drive an already-running instance
 //   --port <n>        port for the spawned server (default 4317)
-//   --scene <a,b,c>   run only these scenes, in this order (default: all)
-//   --no-concat       leave per-scene files in out/, skip the final mp4
-//   --keep            don't delete per-scene intermediates after concat
+//   --scene <a,b,c>   record only these scenes (comma-separated names from scenes/index.mjs)
+//   --force           record every scene even if its file exists
+//   --stitch          skip recording
+//   --no-stitch       skip the final concat
 //
-// Each scene is one Playwright browser context with recordVideo, so its webm
-// is self-contained: title card, interactions, outro beat. The chat scene
-// additionally spawns two VHS tapes in parallel and composes the three
-// recordings side by side. ffmpeg then transcodes every scene to a common
-// 1920x1080 H.264 stream and concatenates.
+// Layout of out/
+//   raw/<scene>.webm            Playwright capture (and <scene>.<tape>.mp4 for tape scenes)
+//   scenes/<scene>.mp4          normalized 1920x1080 H.264 30fps, speed applied
+//   demo.mp4                    every scene in scenes/index.mjs order
+//
+// A scene is { name, run(page, ctx), viewport?, tapes?, room?, speed?, warm? }.
+// warm(page, ctx) runs first in a throwaway page of the same browser context
+// whose video is discarded; use it to fill caches (the graph replays its
+// layout from IndexedDB) so the recorded page opens on the finished state.
 //
 // Requires: node_modules/playwright (npm ci at repo root), a cached Chromium,
 // vhs and ffmpeg on PATH (brew install vhs ffmpeg).
@@ -35,82 +41,101 @@ import { SCENES } from './scenes/index.mjs';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, '..', '..');
 const OUT = join(HERE, 'out');
+const RAW = join(OUT, 'raw');
+const DONE = join(OUT, 'scenes');
 
 const args = parseArgs(process.argv.slice(2));
 const root = args.root ?? process.env.DEMO_ROOT ?? join(homedir(), 'projects', 'noorm');
 const bin = args.bin ?? join(REPO, 'bin', 'atomic');
 const port = Number(args.port ?? 4317);
-const only = args.scene ? args.scene.split(',').map(s => s.trim()) : null;
-const concat = !args['no-concat'] && !only;
 
-mkdirSync(OUT, { recursive: true });
+for (const d of [RAW, DONE]) mkdirSync(d, { recursive: true });
 
-let server = null;
-let base = args.url;
-if (!base) {
-  if (!existsSync(bin)) fail(`no binary at ${bin} — run: make -C atomic build`);
-  base = `http://127.0.0.1:${port}`;
-  server = spawn(bin, ['serve', '--port', String(port)], { cwd: root, stdio: ['ignore', 'pipe', 'pipe'] });
-  server.stderr.on('data', d => process.stderr.write(`[serve] ${d}`));
-  await waitFor(`${base}/api/status`, 15000);
-  console.log(`serving ${root} at ${base}`);
+const sceneFile = s => join(DONE, `${s.name}.mp4`);
+let targets = [];
+if (!args.stitch) {
+  if (args.scene) targets = args.scene.split(',').map(n => SCENES.find(s => s.name === n.trim()) ?? fail(`unknown scene ${n}`));
+  else targets = SCENES.filter(s => args.force || !existsSync(sceneFile(s)));
 }
 
-const browser = await chromium.launch({
-  args: ['--ignore-gpu-blocklist', '--enable-gpu-rasterization', '--force-device-scale-factor=1'],
-});
-
-const produced = [];
-try {
-  const list = only ? only.map(n => SCENES.find(s => s.name === n) ?? fail(`unknown scene ${n}`)) : SCENES;
-  for (const [i, scene] of list.entries()) {
-    const idx = String(i + 1).padStart(2, '0');
-    console.log(`▶ ${idx} ${scene.name}`);
-    const file = await record(scene, idx);
-    produced.push(file);
-    console.log(`  ✓ ${file}`);
+if (targets.length) {
+  let server = null;
+  let base = args.url;
+  if (!base) {
+    if (!existsSync(bin)) fail(`no binary at ${bin} — run: make -C atomic build`);
+    base = `http://127.0.0.1:${port}`;
+    server = spawn(bin, ['serve', '--port', String(port)], { cwd: root, stdio: ['ignore', 'pipe', 'pipe'] });
+    server.stderr.on('data', d => process.stderr.write(`[serve] ${d}`));
+    await waitFor(`${base}/api/status`, 15000);
+    console.log(`serving ${root} at ${base}`);
   }
-} finally {
-  await browser.close();
-  server?.kill('SIGTERM');
+  const browser = await chromium.launch({
+    args: ['--use-gl=angle', '--ignore-gpu-blocklist', '--enable-gpu-rasterization', '--force-device-scale-factor=1'],
+  });
+  try {
+    for (const scene of targets) {
+      console.log(`▶ ${scene.name}`);
+      const raw = await record(browser, scene, base);
+      normalize(raw, sceneFile(scene), scene.speed ?? 1);
+      console.log(`  ✓ ${sceneFile(scene)}`);
+    }
+  } finally {
+    await browser.close();
+    server?.kill('SIGTERM');
+  }
+} else if (!args.stitch) {
+  console.log('nothing to record (every scene present; use --force or --scene)');
 }
 
-if (concat) {
+if (!args['no-stitch']) {
+  const present = SCENES.filter(s => existsSync(sceneFile(s)));
+  const missing = SCENES.filter(s => !existsSync(sceneFile(s))).map(s => s.name);
+  if (missing.length) console.log(`stitching without: ${missing.join(', ')}`);
+  if (!present.length) fail('no scenes to stitch');
   const final = join(OUT, 'demo.mp4');
-  concatenate(produced, final);
-  if (!args.keep) produced.forEach(f => rmSync(f, { force: true }));
+  concatenate(present.map(sceneFile), final);
   console.log(`\n${final}`);
 }
 
-async function record(scene, idx) {
+async function record(browser, scene, base) {
   const viewport = scene.viewport ?? { width: 1920, height: 1080 };
-  const ctx = await browser.newContext({
-    viewport,
-    recordVideo: { dir: OUT, size: viewport },
-    colorScheme: 'dark',
-  });
+  const ctx = await browser.newContext({ viewport, recordVideo: { dir: RAW, size: viewport }, colorScheme: 'dark' });
+  const env = { base, root };
+
+  if (scene.warm) {
+    const w = await ctx.newPage();
+    await scene.warm(w, env);
+    const junk = await w.video().path();
+    await w.close();
+    rmSync(junk, { force: true });
+  }
+
   const page = await ctx.newPage();
   await install(page);
   page.on('pageerror', e => console.warn(`  [pageerror] ${e.message}`));
 
   if (scene.tapes) resetRoom(scene.room);
-  const side = scene.tapes ? runTapes(scene.tapes) : null;
+  const side = scene.tapes ? runTapes(scene) : null;
+  let failure = null;
   try {
-    await scene.run(page, { base, root, idx });
-  } finally {
-    const raw = await page.video().path();
-    await ctx.close();
-    const webm = join(OUT, `${idx}-${scene.name}.webm`);
-    renameSync(raw, webm);
-    if (side) {
-      const tapes = await side;
-      const composed = join(OUT, `${idx}-${scene.name}.composed.mp4`);
-      compose(webm, tapes, composed, viewport);
-      rmSync(webm, { force: true });
-      return composed;
-    }
-    return webm;
+    await scene.run(page, env);
+  } catch (e) {
+    failure = e;
+    await page.screenshot({ path: join(RAW, `${scene.name}.failed.png`) }).catch(() => {});
   }
+  const captured = await page.video().path();
+  await ctx.close();
+  const webm = join(RAW, `${scene.name}.webm`);
+  renameSync(captured, webm);
+  if (side) await side.catch(e => { failure ??= e; });
+  if (failure) fail(`scene ${scene.name} failed: ${failure.message.split('\n')[0]}\n  capture kept at ${webm}; screenshot at ${join(RAW, `${scene.name}.failed.png`)}`);
+  if (side) {
+    const tapes = await side;
+    const composed = join(RAW, `${scene.name}.composed.mp4`);
+    compose(webm, tapes, composed, viewport);
+    return composed;
+  }
+  return webm;
 }
 
 // The room log under ~/.atomic/rooms/ outlives daemon restarts and room
@@ -125,21 +150,20 @@ function resetRoom(room) {
   rmSync(join(homedir(), '.atomic', 'rooms', `${room}.log`), { force: true });
 }
 
-function runTapes(tapes) {
-  return Promise.all(tapes.map(t => new Promise((res, rej) => {
-    const tape = join(HERE, 'tapes', t);
-    const out = join(OUT, t.replace(/\.tape$/, '.mp4'));
-    const p = spawn('vhs', [tape], {
+function runTapes(scene) {
+  return Promise.all(scene.tapes.map(t => new Promise((res, rej) => {
+    const out = join(RAW, `${scene.name}.${t.replace(/\.tape$/, '.mp4')}`);
+    const p = spawn('vhs', [join(HERE, 'tapes', t), '-o', out], {
       cwd: HERE,
-      env: { ...process.env, DEMO_BIN: bin, DEMO_ROOT: root, DEMO_OUT: OUT },
+      env: { ...process.env, DEMO_BIN: bin, DEMO_ROOT: root },
       stdio: ['ignore', 'inherit', 'inherit'],
     });
     p.on('exit', c => c === 0 ? res(out) : rej(new Error(`vhs ${t} exited ${c}`)));
   })));
 }
 
-// browser | (tape A over tape B), all cut to the shortest input, onto a
-// 1920x1080 canvas so the concat step sees one stream shape.
+// browser | (tape A over tape B), cut to the shortest input, on a 1920x1080
+// canvas so normalize() sees the same shape as a plain capture.
 function compose(webm, tapes, out, viewport) {
   const termW = 1920 - viewport.width;
   const termH = Math.floor(1080 / tapes.length);
@@ -154,16 +178,20 @@ function compose(webm, tapes, out, viewport) {
   ffmpeg(['-y', ...inputs, '-filter_complex', filter, '-map', '[v]', '-shortest', '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '18', '-preset', 'medium', out]);
 }
 
+function normalize(src, out, speed) {
+  const vf = [
+    'scale=1920:1080:force_original_aspect_ratio=decrease',
+    'pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=#0c0c0e',
+    speed !== 1 ? `setpts=PTS/${speed}` : null,
+    'fps=30', 'format=yuv420p',
+  ].filter(Boolean).join(',');
+  ffmpeg(['-y', '-ss', '0.4', '-i', src, '-vf', vf, '-c:v', 'libx264', '-crf', '18', '-preset', 'medium', '-an', out]);
+}
+
 function concatenate(files, out) {
-  const norm = files.map((f, i) => {
-    const o = join(OUT, `_n${i}.mp4`);
-    ffmpeg(['-y', '-i', f, '-vf', 'scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=#0c0c0e,fps=30,format=yuv420p', '-c:v', 'libx264', '-crf', '18', '-preset', 'medium', '-an', o]);
-    return o;
-  });
   const list = join(OUT, '_concat.txt');
-  writeFileSync(list, norm.map(f => `file '${f}'`).join('\n') + '\n');
+  writeFileSync(list, files.map(f => `file '${f}'`).join('\n') + '\n');
   ffmpeg(['-y', '-f', 'concat', '-safe', '0', '-i', list, '-c', 'copy', out]);
-  norm.forEach(f => rmSync(f, { force: true }));
   rmSync(list, { force: true });
 }
 

--- a/marketing/demo/scenes/about.mjs
+++ b/marketing/demo/scenes/about.mjs
@@ -1,0 +1,24 @@
+import { title, click, glide, beat } from '../lib/overlay.mjs';
+
+// Outro: the About panel (version, bus rooms, wiki and index health), then a
+// closing card.
+export default {
+  name: 'about',
+  async run(page, { base }) {
+    await page.goto(`${base}/`);
+    await page.waitForSelector('#main-pane .page-body');
+    await beat(page, 400);
+
+    await click(page, page.locator('button.icon-rail-btn[aria-label^="About this server"]'), { after: 500 });
+    const about = page.locator('#about-modal.open');
+    await about.waitFor();
+    await beat(page, 1800);
+    const health = about.locator('.about-health, p.about-health-clear').first();
+    if (await health.count()) await glide(page, health, { settle: 1400 });
+    const repo = about.locator('.about-links a').first();
+    if (await repo.count()) await glide(page, repo, { settle: 1000 });
+    await click(page, about.locator('.about-close'), { after: 600 });
+
+    await title(page, { kicker: 'atomic serve', heading: 'atomic claude install', sub: 'github.com/damusix/atomic-claude', hold: 3200 });
+  },
+};

--- a/marketing/demo/scenes/chat.mjs
+++ b/marketing/demo/scenes/chat.mjs
@@ -4,13 +4,14 @@ const ROOM = 'atomic-demo';
 
 // Bus page: open the demo room (the tapes join the same fixed name), wait for the two agents (spawned by the
 // tapes alongside this scene) to start talking, greet each from the browser,
-// then hold on the live transcript. Narrower viewport: the two terminals
+// then hold on the live transcript. Played back at 2x. Narrower viewport: the two terminals
 // take the right 640px of the composed frame.
 export default {
   name: 'chat',
   viewport: { width: 1280, height: 1080 },
   tapes: ['agent-a.tape', 'agent-b.tape'],
   room: ROOM,
+  speed: 2,
   async run(page, { base }) {
     await page.goto(`${base}/bus`);
     await page.waitForSelector('.bus-new-room input');

--- a/marketing/demo/scenes/chat.mjs
+++ b/marketing/demo/scenes/chat.mjs
@@ -1,0 +1,52 @@
+import { title, click, type, beat } from '../lib/overlay.mjs';
+
+const ROOM = 'atomic-demo';
+
+// Bus page: open the demo room (the tapes join the same fixed name), wait for the two agents (spawned by the
+// tapes alongside this scene) to start talking, greet each from the browser,
+// then hold on the live transcript. Narrower viewport: the two terminals
+// take the right 640px of the composed frame.
+export default {
+  name: 'chat',
+  viewport: { width: 1280, height: 1080 },
+  tapes: ['agent-a.tape', 'agent-b.tape'],
+  room: ROOM,
+  async run(page, { base }) {
+    await page.goto(`${base}/bus`);
+    await page.waitForSelector('.bus-new-room input');
+    await title(page, { kicker: '03', heading: 'Message Bus', sub: 'Concurrent Claude sessions talking over named rooms. The browser is one more member.' });
+
+    await type(page, page.locator('.bus-new-room input'), ROOM, { after: 500 });
+    await click(page, page.locator('.bus-new-room button[type="submit"]'), { after: 800 });
+    await page.waitForSelector('section.bus-room-view');
+
+    await page.waitForSelector('.bus-transcript article.bus-msg', { timeout: 90_000 });
+    await beat(page, 4000);
+
+    const composer = page.locator('form.bus-composer textarea');
+    for (const [suffix, text] of [['agent-a', 'hello from the browser'], ['agent-b', 'hello to you too']]) {
+      const name = await memberEndingWith(page, suffix);
+      if (!name) continue;
+      await type(page, composer, `@${name} `, { delay: 60, after: 400 });
+      await page.keyboard.type(text, { delay: 55 });
+      await beat(page, 500);
+      await page.keyboard.press('Enter');
+      await beat(page, 7000);
+    }
+
+    await beat(page, 30_000);
+  },
+};
+
+// Member names carry the realm prefix (noorm-agent-a), so the browser
+// addresses whatever the roster shows rather than the tape's short name.
+async function memberEndingWith(page, suffix, timeout = 45_000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeout) {
+    const names = await page.locator('.bus-members span.bus-member').allTextContents();
+    const hit = names.map(n => n.trim().replace(/[×\s].*$/, '')).find(n => n.endsWith(suffix));
+    if (hit) return hit;
+    await page.waitForTimeout(1000);
+  }
+  return null;
+}

--- a/marketing/demo/scenes/docs.mjs
+++ b/marketing/demo/scenes/docs.mjs
@@ -1,0 +1,49 @@
+import { title, click, type, glide, beat } from '../lib/overlay.mjs';
+
+// Realm index -> a member wiki page -> rail Links tab (filter, kind chip,
+// follow an outbound link) -> rail Graph tab -> back to Overview.
+export default {
+  name: 'docs',
+  async run(page, { base }) {
+    await page.goto(`${base}/`);
+    await page.waitForSelector('#main-pane .page-body');
+    await title(page, { kicker: '01', heading: 'Wiki docs', sub: 'Every markdown file in the realm, rendered, linked, and cross-referenced.' });
+
+    const member = page.locator('div.page-body a[href^="/page/"]', { hasText: 'monorepo' }).first();
+    await click(page, member, { after: 1200 });
+    await page.waitForSelector('#main-pane .page-body');
+    await beat(page, 1200);
+
+    await page.mouse.wheel(0, 700);
+    await beat(page, 1600);
+    await page.mouse.wheel(0, -700);
+    await beat(page, 800);
+
+    const rail = page.locator('#right-rail');
+    await click(page, rail.getByRole('tab', { name: /^Links/ }), { after: 1300 });
+
+    const filter = rail.locator('input.rail-search-input');
+    await type(page, filter, 'core', { after: 1600 });
+    const clear = rail.locator('button.rail-search-clear');
+    if (await clear.isVisible()) await click(page, clear, { after: 900 });
+
+    const chips = rail.locator('button.rail-kind');
+    const md = chips.filter({ hasText: /^md/ }).first();
+    if (await md.count()) {
+      await click(page, md, { after: 1400 });
+      await click(page, chips.filter({ hasText: /^all$/ }).first(), { after: 900 });
+    }
+
+    await click(page, rail.getByRole('tab', { name: 'Graph' }), { after: 3400 });
+    await click(page, rail.getByRole('tab', { name: /^Links/ }), { after: 1000 });
+
+    const outbound = rail.locator('#rail-out-content a.rail-edge.wikilink[href$=".md"]').first();
+    await glide(page, outbound, { settle: 700 });
+    await click(page, outbound, { after: 1400 });
+    await page.waitForSelector('#main-pane .page-body');
+    await beat(page, 1600);
+    await page.mouse.wheel(0, 500);
+    await beat(page, 1400);
+    await click(page, rail.getByRole('tab', { name: 'Overview' }), { after: 1800 });
+  },
+};

--- a/marketing/demo/scenes/docs.mjs
+++ b/marketing/demo/scenes/docs.mjs
@@ -1,49 +1,68 @@
 import { title, click, type, glide, beat } from '../lib/overlay.mjs';
 
-// Realm index -> a member wiki page -> rail Links tab (filter, kind chip,
-// follow an outbound link) -> rail Graph tab -> back to Overview.
+const MEMBER = process.env.DEMO_DOCS_MEMBER ?? 'monorepo';
+
+// Realm index -> Browse drawer (realm / repos / buckets tree) -> a member
+// wiki page -> rail Links tab (filter, kind chip, Graph tab) -> follow an
+// outbound link.
 export default {
   name: 'docs',
   async run(page, { base }) {
     await page.goto(`${base}/`);
     await page.waitForSelector('#main-pane .page-body');
-    await title(page, { kicker: '01', heading: 'Wiki docs', sub: 'Every markdown file in the realm, rendered, linked, and cross-referenced.' });
+    await title(page, { kicker: 'Wiki docs', heading: 'Every markdown file, rendered and linked', sub: 'Realm wiki, member repos, and capture buckets in one tree.' });
+    await beat(page, 600);
 
-    const member = page.locator('div.page-body a[href^="/page/"]', { hasText: 'monorepo' }).first();
-    await click(page, member, { after: 1200 });
+    await click(page, page.locator('button.icon-rail-btn[aria-label="Browse — toggle navigation"]'), { after: 900 });
+    const drawer = page.locator('.nav-drawer[data-open]');
+    await drawer.waitFor();
+    const repo = drawer.locator('.nav-item.nav-folder', { hasText: new RegExp(`^${MEMBER}$`) }).first();
+    if (await repo.count()) {
+      await click(page, repo, { after: 800 });
+      const docs = drawer.locator('.nav-item.nav-folder', { hasText: /^docs$/ }).first();
+      if (await docs.count() && await docs.isVisible()) await click(page, docs, { after: 700 });
+    }
+    await page.mouse.wheel(0, 400);
+    await beat(page, 900);
+    const leaf = drawer.locator(`a.nav-item[href="/page/${MEMBER}/docs/wiki/index.md"]`).first();
+    if (await leaf.count() && await leaf.isVisible()) {
+      await click(page, leaf, { after: 700 });
+    } else {
+      await page.keyboard.press('Escape');
+      await click(page, page.locator('div.page-body a[href^="/page/"]', { hasText: MEMBER }).first(), { after: 700 });
+    }
     await page.waitForSelector('#main-pane .page-body');
+    if (await drawer.isVisible()) {
+      await page.keyboard.press('Escape');
+      await beat(page, 500);
+    }
     await beat(page, 1200);
 
-    await page.mouse.wheel(0, 700);
-    await beat(page, 1600);
-    await page.mouse.wheel(0, -700);
-    await beat(page, 800);
-
     const rail = page.locator('#right-rail');
-    await click(page, rail.getByRole('tab', { name: /^Links/ }), { after: 1300 });
+    await click(page, rail.getByRole('tab', { name: /^Links/ }), { after: 900 });
 
     const filter = rail.locator('input.rail-search-input');
-    await type(page, filter, 'core', { after: 1600 });
+    await type(page, filter, 'core', { after: 1100 });
     const clear = rail.locator('button.rail-search-clear');
-    if (await clear.isVisible()) await click(page, clear, { after: 900 });
+    if (await clear.isVisible()) await click(page, clear, { after: 500 });
 
     const chips = rail.locator('button.rail-kind');
     const md = chips.filter({ hasText: /^md/ }).first();
     if (await md.count()) {
-      await click(page, md, { after: 1400 });
-      await click(page, chips.filter({ hasText: /^all$/ }).first(), { after: 900 });
+      await click(page, md, { after: 1000 });
+      await click(page, chips.filter({ hasText: /^all$/ }).first(), { after: 500 });
     }
 
-    await click(page, rail.getByRole('tab', { name: 'Graph' }), { after: 3400 });
-    await click(page, rail.getByRole('tab', { name: /^Links/ }), { after: 1000 });
+    await click(page, rail.getByRole('tab', { name: 'Graph' }), { after: 2400 });
+    await click(page, rail.getByRole('tab', { name: /^Links/ }), { after: 600 });
 
     const outbound = rail.locator('#rail-out-content a.rail-edge.wikilink[href$=".md"]').first();
-    await glide(page, outbound, { settle: 700 });
-    await click(page, outbound, { after: 1400 });
+    await glide(page, outbound, { settle: 500 });
+    await click(page, outbound, { after: 900 });
     await page.waitForSelector('#main-pane .page-body');
-    await beat(page, 1600);
+    await beat(page, 900);
     await page.mouse.wheel(0, 500);
-    await beat(page, 1400);
-    await click(page, rail.getByRole('tab', { name: 'Overview' }), { after: 1800 });
+    await beat(page, 900);
+    await click(page, rail.getByRole('tab', { name: 'Overview' }), { after: 1200 });
   },
 };

--- a/marketing/demo/scenes/external.mjs
+++ b/marketing/demo/scenes/external.mjs
@@ -1,0 +1,24 @@
+import { title, click, beat } from '../lib/overlay.mjs';
+
+// External links registry: every outbound URL in the realm grouped by
+// domain, each row naming the pages that cite it and when it first appeared.
+export default {
+  name: 'external',
+  async run(page, { base }) {
+    await page.goto(`${base}/external`);
+    await page.waitForSelector('details.external-domain');
+    await title(page, { kicker: 'External links', heading: 'Every outbound URL, by domain', sub: 'Which pages cite it, and when it first showed up.' });
+    await beat(page, 900);
+
+    const groups = page.locator('details.external-domain');
+    await click(page, groups.nth(0).locator('summary'), { after: 1500 });
+    await page.mouse.wheel(0, 500);
+    await beat(page, 1200);
+    await page.mouse.wheel(0, -500);
+    await click(page, groups.nth(0).locator('summary'), { after: 500 });
+    if ((await groups.count()) > 2) {
+      await click(page, groups.nth(2).locator('summary'), { after: 1500 });
+    }
+    await beat(page, 600);
+  },
+};

--- a/marketing/demo/scenes/graph.mjs
+++ b/marketing/demo/scenes/graph.mjs
@@ -1,57 +1,87 @@
 import { title, click, type, glide, beat } from '../lib/overlay.mjs';
 
-const SETTLE_MS = Number(process.env.DEMO_SETTLE_MS ?? 40_000);
+const SETTLE_MS = Number(process.env.DEMO_SETTLE_MS ?? 60_000);
 const MEMBER = process.env.DEMO_GRAPH_MEMBER ?? 'monorepo';
 
-// Docs graph: settle, shift-hover the biggest node for its preview card,
-// shift-drag it, search. Then the code graph for one member.
+// Docs graph and code graph, both already laid out: the warm-up page runs
+// the simulation once so the recorded page replays the cached layout with
+// no motion. Then: shift-hover the hub for its preview, ctrl-click to pin
+// and highlight its neighbourhood, plain click to open it, search, and the
+// same on the code graph.
 //
 // Nodes are GPU-picked inside a canvas, so positions come from
 // window.GraphCore.debugState() (container-relative screen coords) and the
 // pointer is driven there by hand.
 export default {
   name: 'graph',
+  async warm(page, { base }) {
+    await page.goto(`${base}/graph`);
+    await page.waitForFunction(() => window.GraphCore, null, { timeout: 30_000 });
+    await settle(page);
+    await page.goto(`${base}/graph?view=code&member=${MEMBER}`);
+    await page.waitForFunction(() => window.GraphCore, null, { timeout: 30_000 });
+    await settle(page);
+    await page.waitForTimeout(1500);
+  },
   async run(page, { base }) {
     await page.goto(`${base}/graph`);
     await page.waitForFunction(() => window.GraphCore, null, { timeout: 30_000 });
-    await title(page, { kicker: '05', heading: 'Network graph', sub: 'Every page and every symbol as one force-directed map.' });
     await settle(page);
-    await beat(page, 2500);
+    await title(page, { kicker: 'Network graph', heading: 'Every page and every symbol, one map', sub: 'Shift to highlight and drag, ctrl-click to pin, click to open.' });
+    await beat(page, 1200);
 
     let node = await biggestNode(page);
     if (node) {
       await hoverNode(page, node);
-      await beat(page, 2800);
+      await beat(page, 2200);
       await page.keyboard.up('Shift');
-      await beat(page, 600);
+      await beat(page, 400);
 
-      await dragNode(page, node, { dx: 160, dy: -90 });
-      await page.waitForFunction(() => window.GraphCore.simRunning() === false, null, { timeout: SETTLE_MS }).catch(() => {});
-      await beat(page, 1500);
+      await ctrlClick(page, node);
+      await beat(page, 2400);
+
+      await plainClick(page, node);
+      const modal = await page.waitForSelector('#cy-page-modal-scrim.open', { timeout: 5000 }).catch(() => null);
+      if (modal) {
+        await beat(page, 2400);
+        await page.keyboard.press('Escape');
+        await beat(page, 500);
+      }
+      await page.keyboard.press('Escape');
+      await beat(page, 400);
     }
 
     const search = page.locator('input.graph-search-input');
-    await type(page, search, 'core', { after: 2200 });
+    await type(page, search, 'change', { after: 1800 });
     const clear = page.locator('button.graph-search-clear');
-    if (await clear.isVisible()) await click(page, clear, { after: 800 });
+    if (await clear.isVisible()) await click(page, clear, { after: 500 });
 
-    await click(page, page.locator('button[data-graph-view="code"]'), { after: 800 });
+    await click(page, page.locator('button[data-graph-view="code"]'), { after: 600 });
     const sel = page.locator('select#graph-member-select');
     if (await sel.waitFor({ timeout: 8000 }).then(() => true, () => false)) {
-      await glide(page, sel, { settle: 500 });
+      await glide(page, sel, { settle: 400 });
       await sel.selectOption(MEMBER);
-      await beat(page, 800);
     }
     await settle(page);
-    await beat(page, 3000);
+    await beat(page, 1800);
 
     node = await biggestNode(page);
     if (node) {
       await hoverNode(page, node);
-      await beat(page, 2800);
+      await beat(page, 2200);
       await page.keyboard.up('Shift');
+      await beat(page, 400);
+      await ctrlClick(page, node);
+      await beat(page, 2200);
+      await plainClick(page, node);
+      const modal = await page.waitForSelector('#code-modal.open', { timeout: 5000 }).catch(() => null);
+      if (modal) {
+        await beat(page, 2600);
+        await page.keyboard.press('Escape');
+      }
+      await page.keyboard.press('Escape');
     }
-    await beat(page, 2000);
+    await beat(page, 1200);
   },
 };
 
@@ -70,31 +100,41 @@ async function biggestNode(page) {
     for (const [id, n] of Object.entries(st.nodes ?? {})) {
       if (!n.screen) continue;
       const x = r.left + n.screen.x, y = r.top + n.screen.y;
-      if (x < r.left + 80 || x > r.right - 80 || y < r.top + 80 || y > r.bottom - 80) continue;
+      if (x < r.left + 120 || x > r.right - 120 || y < r.top + 120 || y > r.bottom - 120) continue;
       if (!best || (n.size ?? 0) > best.size) best = { id, x, y, size: n.size ?? 0 };
     }
     return best;
   });
 }
 
-async function hoverNode(page, { x, y }) {
+async function moveTo(page, { x, y }) {
   const from = page.__demoPos ?? { x: 200, y: 200 };
-  for (let i = 1; i <= 30; i++) {
-    const t = i / 30, e = 1 - Math.pow(1 - t, 3);
+  for (let i = 1; i <= 26; i++) {
+    const t = i / 26, e = 1 - Math.pow(1 - t, 3);
     await page.mouse.move(from.x + (x - from.x) * e, from.y + (y - from.y) * e);
     await page.waitForTimeout(12);
   }
   page.__demoPos = { x, y };
+}
+
+async function hoverNode(page, node) {
+  await moveTo(page, node);
   await page.keyboard.down('Shift');
   await page.waitForSelector('#cy-preview-card.open', { timeout: 5000 }).catch(() => {});
 }
 
-async function dragNode(page, { x, y }, { dx, dy }) {
-  await page.mouse.move(x, y);
-  await page.keyboard.down('Shift');
+async function ctrlClick(page, node) {
+  await moveTo(page, node);
+  await page.keyboard.down('Control');
   await page.mouse.down();
-  await page.mouse.move(x + dx, y + dy, { steps: 30 });
+  await page.waitForTimeout(60);
   await page.mouse.up();
-  await page.keyboard.up('Shift');
-  page.__demoPos = { x: x + dx, y: y + dy };
+  await page.keyboard.up('Control');
+}
+
+async function plainClick(page, node) {
+  await moveTo(page, node);
+  await page.mouse.down();
+  await page.waitForTimeout(60);
+  await page.mouse.up();
 }

--- a/marketing/demo/scenes/graph.mjs
+++ b/marketing/demo/scenes/graph.mjs
@@ -1,0 +1,100 @@
+import { title, click, type, glide, beat } from '../lib/overlay.mjs';
+
+const SETTLE_MS = Number(process.env.DEMO_SETTLE_MS ?? 40_000);
+const MEMBER = process.env.DEMO_GRAPH_MEMBER ?? 'monorepo';
+
+// Docs graph: settle, shift-hover the biggest node for its preview card,
+// shift-drag it, search. Then the code graph for one member.
+//
+// Nodes are GPU-picked inside a canvas, so positions come from
+// window.GraphCore.debugState() (container-relative screen coords) and the
+// pointer is driven there by hand.
+export default {
+  name: 'graph',
+  async run(page, { base }) {
+    await page.goto(`${base}/graph`);
+    await page.waitForFunction(() => window.GraphCore, null, { timeout: 30_000 });
+    await title(page, { kicker: '05', heading: 'Network graph', sub: 'Every page and every symbol as one force-directed map.' });
+    await settle(page);
+    await beat(page, 2500);
+
+    let node = await biggestNode(page);
+    if (node) {
+      await hoverNode(page, node);
+      await beat(page, 2800);
+      await page.keyboard.up('Shift');
+      await beat(page, 600);
+
+      await dragNode(page, node, { dx: 160, dy: -90 });
+      await page.waitForFunction(() => window.GraphCore.simRunning() === false, null, { timeout: SETTLE_MS }).catch(() => {});
+      await beat(page, 1500);
+    }
+
+    const search = page.locator('input.graph-search-input');
+    await type(page, search, 'core', { after: 2200 });
+    const clear = page.locator('button.graph-search-clear');
+    if (await clear.isVisible()) await click(page, clear, { after: 800 });
+
+    await click(page, page.locator('button[data-graph-view="code"]'), { after: 800 });
+    const sel = page.locator('select#graph-member-select');
+    if (await sel.waitFor({ timeout: 8000 }).then(() => true, () => false)) {
+      await glide(page, sel, { settle: 500 });
+      await sel.selectOption(MEMBER);
+      await beat(page, 800);
+    }
+    await settle(page);
+    await beat(page, 3000);
+
+    node = await biggestNode(page);
+    if (node) {
+      await hoverNode(page, node);
+      await beat(page, 2800);
+      await page.keyboard.up('Shift');
+    }
+    await beat(page, 2000);
+  },
+};
+
+async function settle(page) {
+  await page.waitForSelector('.system-graph-loading', { state: 'hidden', timeout: SETTLE_MS }).catch(() => {});
+  await page.waitForFunction(() => window.GraphCore.simRunning() === false, null, { timeout: SETTLE_MS }).catch(() => {});
+}
+
+async function biggestNode(page) {
+  return page.evaluate(() => {
+    const c = document.querySelector('[data-system-graph],[data-code-graph]');
+    if (!c || !window.GraphCore) return null;
+    const r = c.getBoundingClientRect();
+    const st = window.GraphCore.debugState();
+    let best = null;
+    for (const [id, n] of Object.entries(st.nodes ?? {})) {
+      if (!n.screen) continue;
+      const x = r.left + n.screen.x, y = r.top + n.screen.y;
+      if (x < r.left + 80 || x > r.right - 80 || y < r.top + 80 || y > r.bottom - 80) continue;
+      if (!best || (n.size ?? 0) > best.size) best = { id, x, y, size: n.size ?? 0 };
+    }
+    return best;
+  });
+}
+
+async function hoverNode(page, { x, y }) {
+  const from = page.__demoPos ?? { x: 200, y: 200 };
+  for (let i = 1; i <= 30; i++) {
+    const t = i / 30, e = 1 - Math.pow(1 - t, 3);
+    await page.mouse.move(from.x + (x - from.x) * e, from.y + (y - from.y) * e);
+    await page.waitForTimeout(12);
+  }
+  page.__demoPos = { x, y };
+  await page.keyboard.down('Shift');
+  await page.waitForSelector('#cy-preview-card.open', { timeout: 5000 }).catch(() => {});
+}
+
+async function dragNode(page, { x, y }, { dx, dy }) {
+  await page.mouse.move(x, y);
+  await page.keyboard.down('Shift');
+  await page.mouse.down();
+  await page.mouse.move(x + dx, y + dy, { steps: 30 });
+  await page.mouse.up();
+  await page.keyboard.up('Shift');
+  page.__demoPos = { x: x + dx, y: y + dy };
+}

--- a/marketing/demo/scenes/index.mjs
+++ b/marketing/demo/scenes/index.mjs
@@ -1,0 +1,8 @@
+import docs from './docs.mjs';
+import schema from './schema.mjs';
+import chat from './chat.mjs';
+import plans from './plans.mjs';
+import graph from './graph.mjs';
+
+// Tour order. A scene is { name, run(page, ctx), viewport?, tapes? }.
+export const SCENES = [docs, schema, chat, plans, graph];

--- a/marketing/demo/scenes/index.mjs
+++ b/marketing/demo/scenes/index.mjs
@@ -1,8 +1,13 @@
 import docs from './docs.mjs';
+import search from './search.mjs';
 import schema from './schema.mjs';
 import chat from './chat.mjs';
 import plans from './plans.mjs';
+import external from './external.mjs';
 import graph from './graph.mjs';
+import about from './about.mjs';
 
-// Tour order. A scene is { name, run(page, ctx), viewport?, tapes? }.
-export const SCENES = [docs, schema, chat, plans, graph];
+// Tour order. A scene is { name, run(page, ctx), viewport?, tapes?, room?, speed?, warm? }.
+// Adding one: create scenes/<name>.mjs, import it here, place it, then
+// `node marketing/demo/run.mjs` records just that one and re-stitches.
+export const SCENES = [docs, search, schema, chat, plans, external, graph, about];

--- a/marketing/demo/scenes/plans.mjs
+++ b/marketing/demo/scenes/plans.mjs
@@ -1,0 +1,53 @@
+import { title, click, type, glide, beat } from '../lib/overlay.mjs';
+
+const MEMBER = process.env.DEMO_PLAN_MEMBER ?? 'monorepo';
+const SLUG = process.env.DEMO_PLAN_SLUG ?? 'config-access-roles';
+
+// Plans list for one member -> filter to a slug -> its spec -> pick another
+// version from the rail -> the design doc -> the scratchpad bundle files.
+export default {
+  name: 'plans',
+  async run(page, { base }) {
+    await page.goto(`${base}/plans?member=${MEMBER}`);
+    await page.waitForSelector('li.plans-row');
+    await title(page, { kicker: '04', heading: 'Plans', sub: 'Every unit of work: its design, its spec, every version across worktrees, and the live scratchpad.' });
+
+    await page.mouse.wheel(0, 500);
+    await beat(page, 1400);
+    await page.mouse.wheel(0, -500);
+    await beat(page, 600);
+
+    await type(page, page.locator('input.plans-filter-input'), SLUG.split('-')[0], { after: 1300 });
+    const row = page.locator('li.plans-row', { has: page.locator('span.plans-row-slug', { hasText: SLUG }) }).first();
+    await glide(page, row.locator('span.plans-row-dots'), { settle: 900 });
+    await click(page, row.locator('span.plans-row-title'), { after: 800 });
+    await page.waitForSelector('[data-route="plans-slug"] .page-body, [data-route="plans-slug"]');
+    await beat(page, 2200);
+
+    const rail = page.locator('#right-rail');
+    const entry = (label) => rail.locator('.bnav div', { hasText: new RegExp(`^${label}$`) });
+    for (const label of ['BRIEF.md', 'STATE.md', 'design.md']) {
+      if (!(await entry(label).count())) continue;
+      await click(page, entry(label), { after: 600 });
+      await page.waitForSelector('[data-route="plans-slug"]');
+      await beat(page, label === 'design.md' ? 2400 : 1700);
+      if (label === 'design.md') {
+        await page.mouse.wheel(0, 600);
+        await beat(page, 1400);
+      }
+    }
+
+    await click(page, entry('spec.md'), { after: 1200 });
+    const picker = rail.locator('input.vpick-input');
+    if (await picker.count()) {
+      await click(page, picker, { after: 1000 });
+      const opts = rail.locator('.vmenu .vopt');
+      if ((await opts.count()) > 1) {
+        await click(page, opts.filter({ hasNot: page.locator('.on') }).nth(1), { after: 2600 });
+      } else {
+        await page.keyboard.press('Escape');
+      }
+    }
+    await beat(page, 800);
+  },
+};

--- a/marketing/demo/scenes/plans.mjs
+++ b/marketing/demo/scenes/plans.mjs
@@ -3,51 +3,43 @@ import { title, click, type, glide, beat } from '../lib/overlay.mjs';
 const MEMBER = process.env.DEMO_PLAN_MEMBER ?? 'monorepo';
 const SLUG = process.env.DEMO_PLAN_SLUG ?? 'config-access-roles';
 
-// Plans list for one member -> filter to a slug -> its spec -> pick another
-// version from the rail -> the design doc -> the scratchpad bundle files.
+// Plans list for one member -> filter to a slug -> its spec -> the scratchpad
+// bundle files -> the design doc -> back to the spec and another version.
 export default {
   name: 'plans',
   async run(page, { base }) {
     await page.goto(`${base}/plans?member=${MEMBER}`);
     await page.waitForSelector('li.plans-row');
-    await title(page, { kicker: '04', heading: 'Plans', sub: 'Every unit of work: its design, its spec, every version across worktrees, and the live scratchpad.' });
+    await title(page, { kicker: 'Plans', heading: 'Design, spec, every version, live scratchpad', sub: 'One row per unit of work, read across every worktree of the repo.' });
+    await beat(page, 900);
 
-    await page.mouse.wheel(0, 500);
-    await beat(page, 1400);
-    await page.mouse.wheel(0, -500);
-    await beat(page, 600);
-
-    await type(page, page.locator('input.plans-filter-input'), SLUG.split('-')[0], { after: 1300 });
+    await type(page, page.locator('input.plans-filter-input'), SLUG.split('-')[0], { after: 900 });
     const row = page.locator('li.plans-row', { has: page.locator('span.plans-row-slug', { hasText: SLUG }) }).first();
-    await glide(page, row.locator('span.plans-row-dots'), { settle: 900 });
-    await click(page, row.locator('span.plans-row-title'), { after: 800 });
-    await page.waitForSelector('[data-route="plans-slug"] .page-body, [data-route="plans-slug"]');
-    await beat(page, 2200);
+    await glide(page, row.locator('span.plans-row-dots'), { settle: 700 });
+    await click(page, row.locator('span.plans-row-title'), { after: 500 });
+    await page.waitForSelector('[data-route="plans-slug"]');
+    await beat(page, 1600);
 
     const rail = page.locator('#right-rail');
     const entry = (label) => rail.locator('.bnav div', { hasText: new RegExp(`^${label}$`) });
     for (const label of ['BRIEF.md', 'STATE.md', 'design.md']) {
       if (!(await entry(label).count())) continue;
-      await click(page, entry(label), { after: 600 });
+      await click(page, entry(label), { after: 400 });
       await page.waitForSelector('[data-route="plans-slug"]');
-      await beat(page, label === 'design.md' ? 2400 : 1700);
-      if (label === 'design.md') {
-        await page.mouse.wheel(0, 600);
-        await beat(page, 1400);
-      }
+      await beat(page, label === 'design.md' ? 1800 : 1200);
     }
 
-    await click(page, entry('spec.md'), { after: 1200 });
+    await click(page, entry('spec.md'), { after: 800 });
     const picker = rail.locator('input.vpick-input');
     if (await picker.count()) {
-      await click(page, picker, { after: 1000 });
+      await click(page, picker, { after: 700 });
       const opts = rail.locator('.vmenu .vopt');
       if ((await opts.count()) > 1) {
-        await click(page, opts.filter({ hasNot: page.locator('.on') }).nth(1), { after: 2600 });
+        await click(page, opts.filter({ hasNot: page.locator('.on') }).nth(1), { after: 1800 });
       } else {
         await page.keyboard.press('Escape');
       }
     }
-    await beat(page, 800);
+    await beat(page, 500);
   },
 };

--- a/marketing/demo/scenes/schema.mjs
+++ b/marketing/demo/scenes/schema.mjs
@@ -1,0 +1,58 @@
+import { title, click, type, glide, beat } from '../lib/overlay.mjs';
+
+const MEMBER = process.env.DEMO_SCHEMA_MEMBER ?? 'monorepo';
+const TABLE = process.env.DEMO_SCHEMA_TABLE ?? 'Milestone';
+
+// Schema page for one member -> filter to a table -> open the table's source
+// in the code modal -> open a "Written by" query -> open a "Read by" source.
+export default {
+  name: 'schema',
+  async run(page, { base }) {
+    await page.goto(`${base}/code/schema?member=${MEMBER}`);
+    await page.waitForSelector('div.code-schema-table');
+    await title(page, { kicker: '02', heading: 'SQL schema', sub: 'Tables, views, keys, and which code reads or writes each one. Built from the source, not a live database.' });
+
+    await page.mouse.wheel(0, 900);
+    await beat(page, 1600);
+    await page.mouse.wheel(0, -900);
+    await beat(page, 700);
+
+    const filter = page.locator('input.code-schema-search-input');
+    await type(page, filter, TABLE, { after: 1500 });
+
+    const card = page.locator('div.code-schema-table', { has: page.locator('h4.code-schema-table-name button', { hasText: new RegExp(`^${TABLE}$`) }) }).first();
+    await card.waitFor();
+    await glide(page, card.locator('ul, .code-schema-columns').first(), { settle: 1200 });
+
+    await click(page, card.locator('h4.code-schema-table-name button'), { after: 600 });
+    await page.waitForSelector('#code-modal.open');
+    await beat(page, 3200);
+    await page.keyboard.press('Escape');
+    await beat(page, 900);
+
+    const writers = card.locator('div.code-schema-relation', { hasText: 'Written by' });
+    if (await writers.count()) {
+      await glide(page, writers.locator('.code-schema-relation-label'), { settle: 900 });
+      await click(page, writers.locator('button.code-node-link').first(), { after: 600 });
+      await page.waitForSelector('#code-modal.open');
+      await beat(page, 3200);
+      await page.keyboard.press('Escape');
+      await beat(page, 900);
+    }
+
+    let readers = card.locator('div.code-schema-relation', { hasText: 'Read by' });
+    if (!(await readers.count())) {
+      const clear = page.locator('button.code-schema-search-clear');
+      if (await clear.isVisible()) await click(page, clear, { after: 900 });
+      readers = page.locator('div.code-schema-relation', { hasText: 'Read by' }).first();
+    }
+    if (await readers.count()) {
+      await glide(page, readers.locator('.code-schema-relation-label').first(), { settle: 900 });
+      await click(page, readers.locator('button.code-node-link').first(), { after: 600 });
+      await page.waitForSelector('#code-modal.open');
+      await beat(page, 3000);
+      await page.keyboard.press('Escape');
+      await beat(page, 1200);
+    }
+  },
+};

--- a/marketing/demo/scenes/schema.mjs
+++ b/marketing/demo/scenes/schema.mjs
@@ -10,49 +10,45 @@ export default {
   async run(page, { base }) {
     await page.goto(`${base}/code/schema?member=${MEMBER}`);
     await page.waitForSelector('div.code-schema-table');
-    await title(page, { kicker: '02', heading: 'SQL schema', sub: 'Tables, views, keys, and which code reads or writes each one. Built from the source, not a live database.' });
-
-    await page.mouse.wheel(0, 900);
-    await beat(page, 1600);
-    await page.mouse.wheel(0, -900);
-    await beat(page, 700);
+    await title(page, { kicker: 'SQL schema', heading: 'Tables, keys, readers, writers', sub: 'Built from the SQL in the repo, not from a live database.' });
+    await beat(page, 900);
 
     const filter = page.locator('input.code-schema-search-input');
-    await type(page, filter, TABLE, { after: 1500 });
+    await type(page, filter, TABLE, { after: 1100 });
 
     const card = page.locator('div.code-schema-table', { has: page.locator('h4.code-schema-table-name button', { hasText: new RegExp(`^${TABLE}$`) }) }).first();
     await card.waitFor();
-    await glide(page, card.locator('ul, .code-schema-columns').first(), { settle: 1200 });
+    await glide(page, card.locator('ul, .code-schema-columns').first(), { settle: 900 });
 
-    await click(page, card.locator('h4.code-schema-table-name button'), { after: 600 });
+    await click(page, card.locator('h4.code-schema-table-name button'), { after: 400 });
     await page.waitForSelector('#code-modal.open');
-    await beat(page, 3200);
+    await beat(page, 2600);
     await page.keyboard.press('Escape');
-    await beat(page, 900);
+    await beat(page, 600);
 
     const writers = card.locator('div.code-schema-relation', { hasText: 'Written by' });
     if (await writers.count()) {
-      await glide(page, writers.locator('.code-schema-relation-label'), { settle: 900 });
-      await click(page, writers.locator('button.code-node-link').first(), { after: 600 });
+      await glide(page, writers.locator('.code-schema-relation-label'), { settle: 700 });
+      await click(page, writers.locator('button.code-node-link').first(), { after: 400 });
       await page.waitForSelector('#code-modal.open');
-      await beat(page, 3200);
+      await beat(page, 2600);
       await page.keyboard.press('Escape');
-      await beat(page, 900);
+      await beat(page, 600);
     }
 
     let readers = card.locator('div.code-schema-relation', { hasText: 'Read by' });
     if (!(await readers.count())) {
       const clear = page.locator('button.code-schema-search-clear');
-      if (await clear.isVisible()) await click(page, clear, { after: 900 });
+      if (await clear.isVisible()) await click(page, clear, { after: 700 });
       readers = page.locator('div.code-schema-relation', { hasText: 'Read by' }).first();
     }
     if (await readers.count()) {
-      await glide(page, readers.locator('.code-schema-relation-label').first(), { settle: 900 });
-      await click(page, readers.locator('button.code-node-link').first(), { after: 600 });
+      await glide(page, readers.locator('.code-schema-relation-label').first(), { settle: 700 });
+      await click(page, readers.locator('button.code-node-link').first(), { after: 400 });
       await page.waitForSelector('#code-modal.open');
-      await beat(page, 3000);
+      await beat(page, 2400);
       await page.keyboard.press('Escape');
-      await beat(page, 1200);
+      await beat(page, 800);
     }
   },
 };

--- a/marketing/demo/scenes/search.mjs
+++ b/marketing/demo/scenes/search.mjs
@@ -1,6 +1,7 @@
 import { title, click, type, glide, beat } from '../lib/overlay.mjs';
 
 const QUERY = process.env.DEMO_SEARCH_QUERY ?? 'change';
+const MEMBER = process.env.DEMO_SEARCH_MEMBER ?? 'monorepo';
 
 // Command-K palette: one query across markdown, code symbols, and plans.
 // A code hit opens the code modal: find-in-file, then the symbol's callers
@@ -9,7 +10,9 @@ const QUERY = process.env.DEMO_SEARCH_QUERY ?? 'change';
 export default {
   name: 'search',
   async run(page, { base }) {
-    await page.goto(`${base}/`);
+    // The palette's plans tab is scoped by ?member= on the current URL; from
+    // the bare realm root it searches the empty local scope.
+    await page.goto(`${base}/page/${MEMBER}/docs/wiki/index.md?member=${MEMBER}`);
     await page.waitForSelector('#main-pane .page-body');
     await title(page, { kicker: 'Search', heading: 'One box: markdown, symbols, plans', sub: 'Command-K anywhere. Code hits open straight into the source.' });
     await beat(page, 500);
@@ -38,8 +41,8 @@ export default {
 
     await click(page, toggle('plans'), { after: 300 });
     await retype();
-    await results.locator('[role="option"], p.md-search-empty').first().waitFor({ timeout: 10_000 });
-    await beat(page, 1400);
+    await results.locator('[role="option"][data-value^="plans:"]').first().waitFor({ timeout: 10_000 });
+    await beat(page, 1600);
 
     await click(page, toggle('code'), { after: 300 });
     await retype();

--- a/marketing/demo/scenes/search.mjs
+++ b/marketing/demo/scenes/search.mjs
@@ -46,7 +46,9 @@ export default {
 
     await click(page, toggle('code'), { after: 300 });
     await retype();
-    const hit = results.locator('[role="option"][data-value^="code:"]').first();
+    // A hit from the demo member: its index is the one prep.sh refreshes, so
+    // the modal is guaranteed source to show.
+    const hit = results.locator(`[role="option"][data-value^="code:${MEMBER}:"]`).first();
     await hit.waitFor({ timeout: 10_000 });
     await click(page, hit, { after: 500 });
     const code = page.locator('#code-modal.open');

--- a/marketing/demo/scenes/search.mjs
+++ b/marketing/demo/scenes/search.mjs
@@ -1,0 +1,88 @@
+import { title, click, type, glide, beat } from '../lib/overlay.mjs';
+
+const QUERY = process.env.DEMO_SEARCH_QUERY ?? 'change';
+
+// Command-K palette: one query across markdown, code symbols, and plans.
+// A code hit opens the code modal: find-in-file, then the symbol's callers
+// in the intel pane, one hop in, Back. Then "View all results" lands on the
+// full search page.
+export default {
+  name: 'search',
+  async run(page, { base }) {
+    await page.goto(`${base}/`);
+    await page.waitForSelector('#main-pane .page-body');
+    await title(page, { kicker: 'Search', heading: 'One box: markdown, symbols, plans', sub: 'Command-K anywhere. Code hits open straight into the source.' });
+    await beat(page, 500);
+
+    const trigger = page.locator('button.search-trigger');
+    await click(page, trigger, { after: 500 });
+    const modal = page.locator('#search-modal.open');
+    await modal.waitFor();
+    await page.keyboard.type(QUERY, { delay: 70 });
+    // Rows are Ark combobox options keyed md:/code:/plan: in data-value.
+    const results = page.locator('.search-results');
+    await results.locator('[role="option"][data-value^="md:"]').first().waitFor({ timeout: 10_000 });
+    await beat(page, 1800);
+
+    // Changing the source clears the query, so it is typed again each time.
+    const toggle = name => modal.locator('.search-toggle button.toggle-btn', { hasText: new RegExp(`^${name}$`) });
+    const retype = async () => {
+      await click(page, modal.locator('input.search-modal-input'), { after: 150 });
+      await page.keyboard.press('ControlOrMeta+a');
+      await page.keyboard.type(QUERY, { delay: 60 });
+    };
+    await click(page, toggle('code'), { after: 300 });
+    await retype();
+    await results.locator('[role="option"][data-value^="code:"]').first().waitFor({ timeout: 10_000 });
+    await beat(page, 1600);
+
+    await click(page, toggle('plans'), { after: 300 });
+    await retype();
+    await results.locator('[role="option"], p.md-search-empty').first().waitFor({ timeout: 10_000 });
+    await beat(page, 1400);
+
+    await click(page, toggle('code'), { after: 300 });
+    await retype();
+    const hit = results.locator('[role="option"][data-value^="code:"]').first();
+    await hit.waitFor({ timeout: 10_000 });
+    await click(page, hit, { after: 500 });
+    const code = page.locator('#code-modal.open');
+    await code.waitFor();
+    await beat(page, 1600);
+
+    const find = code.locator('input.code-find-input');
+    await type(page, find, 'return', { delay: 70, after: 700 });
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press('Enter');
+      await beat(page, 650);
+    }
+    await beat(page, 400);
+
+    const intel = code.locator('#code-modal-intel');
+    const callers = intel.locator('nav.code-node-nav button', { hasText: /^callers$/ });
+    if (await callers.count()) {
+      await click(page, callers, { after: 600 });
+      const chip = intel.locator('button.code-edge-chip-link').first();
+      if (await chip.waitFor({ timeout: 6000 }).then(() => true, () => false)) {
+        await beat(page, 900);
+        await click(page, chip, { after: 1600 });
+        const back = code.locator('button.code-modal-intel-back');
+        if (await back.isVisible()) await click(page, back, { after: 1100 });
+      }
+    }
+    await click(page, code.locator('.code-modal-close'), { after: 700 });
+
+    await click(page, trigger, { after: 400 });
+    await modal.waitFor();
+    await retype();
+    await results.locator('[role="option"]').first().waitFor({ timeout: 10_000 });
+    await beat(page, 500);
+    await click(page, modal.locator('button.search-viewall'), { after: 800 });
+    await page.waitForSelector('[data-route="search"]');
+    await beat(page, 1400);
+    const codeTab = page.locator('.search-page-tabs button.search-tab', { hasText: /^Code$/ });
+    if (await codeTab.count()) await click(page, codeTab, { after: 1400 });
+    await page.mouse.wheel(0, 500);
+    await beat(page, 1000);
+  },
+};

--- a/marketing/demo/tapes/agent-a.tape
+++ b/marketing/demo/tapes/agent-a.tape
@@ -1,0 +1,40 @@
+# Left terminal of the chat scene: a Sonnet agent that joins the demo room,
+# greets agent-b, then answers whatever is addressed to it. Spawned by
+# run.mjs with DEMO_BIN / DEMO_ROOT in the environment; the Hide block
+# consumes them. Runs ~70s; run.mjs trims all three chat recordings to the
+# shortest.
+#
+# Standalone: DEMO_BIN=bin/atomic DEMO_ROOT=~/projects/noorm vhs marketing/demo/tapes/agent-a.tape
+
+Output out/agent-a.mp4
+
+Set Shell         "zsh"
+Set FontFamily    "JetBrains Mono"
+Set FontSize      15
+Set Width         640
+Set Height        540
+Set Padding       14
+Set Theme         "Catppuccin Mocha"
+Set WindowBar     Colorful
+Set BorderRadius  8
+Set TypingSpeed   35ms
+Set Framerate     30
+
+Hide
+Type `export PATH="$(dirname "$DEMO_BIN"):$PATH"; cd "$DEMO_ROOT"; unset ${(M)${(k)parameters}:#CLAUDE*}; export PROMPT='%F{green}agent-a ❯%f '; clear`
+Enter
+Show
+
+Sleep 600ms
+Type `claude --model sonnet --strict-mcp-config --allowedTools "Bash(atomic bus:*),Monitor"`
+Sleep 400ms
+Enter
+Sleep 5s
+Type `Join bus room atomic-demo as agent-a. Run atomic bus who atomic-demo, then send a short hello addressed to the member whose name ends in agent-b (wait for it to appear if needed). Then watch the room for about 45 seconds and reply briefly to anything addressed to you. No tool use beyond atomic bus.`
+Sleep 600ms
+Enter
+Sleep 62s
+Ctrl+C
+Sleep 300ms
+Ctrl+C
+Sleep 1s

--- a/marketing/demo/tapes/agent-a.tape
+++ b/marketing/demo/tapes/agent-a.tape
@@ -2,11 +2,10 @@
 # greets agent-b, then answers whatever is addressed to it. Spawned by
 # run.mjs with DEMO_BIN / DEMO_ROOT in the environment; the Hide block
 # consumes them. Runs ~70s; run.mjs trims all three chat recordings to the
-# shortest.
+# shortest. Output path comes from vhs -o.
 #
-# Standalone: DEMO_BIN=bin/atomic DEMO_ROOT=~/projects/noorm vhs marketing/demo/tapes/agent-a.tape
+# Standalone: DEMO_BIN=bin/atomic DEMO_ROOT=~/projects/noorm vhs marketing/demo/tapes/agent-a.tape -o /tmp/agent-a.mp4
 
-Output out/agent-a.mp4
 
 Set Shell         "zsh"
 Set FontFamily    "JetBrains Mono"

--- a/marketing/demo/tapes/agent-b.tape
+++ b/marketing/demo/tapes/agent-b.tape
@@ -1,0 +1,40 @@
+# Right terminal of the chat scene: a Sonnet agent that joins the demo room,
+# answers agent-a, then answers whatever is addressed to it. Spawned by
+# run.mjs with DEMO_BIN / DEMO_ROOT in the environment; the Hide block
+# consumes them. Runs ~70s; run.mjs trims all three chat recordings to the
+# shortest.
+#
+# Standalone: DEMO_BIN=bin/atomic DEMO_ROOT=~/projects/noorm vhs marketing/demo/tapes/agent-b.tape
+
+Output out/agent-b.mp4
+
+Set Shell         "zsh"
+Set FontFamily    "JetBrains Mono"
+Set FontSize      15
+Set Width         640
+Set Height        540
+Set Padding       14
+Set Theme         "Catppuccin Mocha"
+Set WindowBar     Colorful
+Set BorderRadius  8
+Set TypingSpeed   35ms
+Set Framerate     30
+
+Hide
+Type `export PATH="$(dirname "$DEMO_BIN"):$PATH"; cd "$DEMO_ROOT"; unset ${(M)${(k)parameters}:#CLAUDE*}; export PROMPT='%F{green}agent-b ❯%f '; clear`
+Enter
+Show
+
+Sleep 600ms
+Type `claude --model sonnet --strict-mcp-config --allowedTools "Bash(atomic bus:*),Monitor"`
+Sleep 400ms
+Enter
+Sleep 6s
+Type `Join bus room atomic-demo as agent-b. Wait for a hello from the member whose name ends in agent-a, reply with a short hello addressed to it, then watch the room for about 45 seconds and reply briefly to anything addressed to you. No tool use beyond atomic bus.`
+Sleep 600ms
+Enter
+Sleep 62s
+Ctrl+C
+Sleep 300ms
+Ctrl+C
+Sleep 1s

--- a/marketing/demo/tapes/agent-b.tape
+++ b/marketing/demo/tapes/agent-b.tape
@@ -2,11 +2,10 @@
 # answers agent-a, then answers whatever is addressed to it. Spawned by
 # run.mjs with DEMO_BIN / DEMO_ROOT in the environment; the Hide block
 # consumes them. Runs ~70s; run.mjs trims all three chat recordings to the
-# shortest.
+# shortest. Output path comes from vhs -o.
 #
-# Standalone: DEMO_BIN=bin/atomic DEMO_ROOT=~/projects/noorm vhs marketing/demo/tapes/agent-b.tape
+# Standalone: DEMO_BIN=bin/atomic DEMO_ROOT=~/projects/noorm vhs marketing/demo/tapes/agent-b.tape -o /tmp/agent-b.mp4
 
-Output out/agent-b.mp4
 
 Set Shell         "zsh"
 Set FontFamily    "JetBrains Mono"


### PR DESCRIPTION
Playwright drives every serve surface (docs, command-K search, schema, bus, plans, external links, graph, about) against a spawned bin/atomic, with an injected cursor and title cards so each scene is one self-contained recording. Scenes land in marketing/demo/out/scenes/<name>.mp4 and a run only records what is missing, so adding or re-shooting one never repeats the tour. The bus scene runs two VHS tapes that launch real Sonnet sessions into a dedicated room; the graph scene warms the layout cache in a throwaway page so the recording opens settled.

Also fixes the /search page tabs, which still carried pre-Ark anchor styles and rendered as native buttons.