### PR TITLE
Show download progress during atomic update

### DIFF
--- a/atomic/cmd/atomic/cmd_update.go
+++ b/atomic/cmd/atomic/cmd_update.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	charmterm "github.com/charmbracelet/x/term"
 	"github.com/damusix/atomic-claude/atomic/internal/cliutil"
 	"github.com/damusix/atomic-claude/atomic/internal/config"
 	"github.com/damusix/atomic-claude/atomic/internal/doctor"
@@ -266,6 +267,8 @@ func runUpdate(args []string) {
 		os.Exit(1)
 	}
 
+	c.OnProgress = downloadProgressRenderer(os.Stdout, charmterm.IsTerminal(os.Stdout.Fd()))
+
 	home, _ := os.UserHomeDir()
 	if err := runUpdateApply(ctx, home, c, channel, version.Version, exe, force, time.Now, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "atomic update: %v\n", err)
@@ -303,6 +306,31 @@ func runUpdate(args []string) {
 	}
 	if shouldRunPostUpdateDoctor(noDoctor, cfgRunDoctor) {
 		updatedoctor.Run(doctor.Run, os.Stdout)
+	}
+}
+
+// downloadProgressRenderer rewrites one status line in place as the archive
+// streams down. Nil off-TTY: without \r rewriting, every tick would print its
+// own line into redirected output.
+func downloadProgressRenderer(w io.Writer, isTTY bool) func(received, total int64) {
+	if !isTTY {
+		return nil
+	}
+	const mib = 1024 * 1024
+	done := false
+	return func(received, total int64) {
+		if done {
+			return
+		}
+		switch {
+		case total > 0 && received >= total:
+			done = true
+			fmt.Fprintf(w, "\rdownloaded %.1f MB (100%%)           \n", float64(total)/mib)
+		case total > 0:
+			fmt.Fprintf(w, "\rdownloading %.1f / %.1f MB (%d%%)   ", float64(received)/mib, float64(total)/mib, received*100/total)
+		default:
+			fmt.Fprintf(w, "\rdownloading %.1f MB   ", float64(received)/mib)
+		}
 	}
 }
 

--- a/atomic/cmd/atomic/cmd_update_progress_test.go
+++ b/atomic/cmd/atomic/cmd_update_progress_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestDownloadProgressRendererNonTTYIsNil(t *testing.T) {
+	if r := downloadProgressRenderer(io.Discard, false); r != nil {
+		t.Fatal("non-TTY must yield a nil renderer: without \\r rewriting each tick prints its own line")
+	}
+}
+
+func TestDownloadProgressRendererRewritesOneLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := downloadProgressRenderer(&buf, true)
+
+	r(512*1024, 2*1024*1024)
+	out := buf.String()
+	if !strings.HasPrefix(out, "\r") {
+		t.Fatalf("progress must rewrite in place with \\r, got %q", out)
+	}
+	if !strings.Contains(out, "0.5") || !strings.Contains(out, "2.0") || !strings.Contains(out, "25%") {
+		t.Fatalf("progress line missing received/total/percent, got %q", out)
+	}
+	if strings.HasSuffix(out, "\n") {
+		t.Fatalf("mid-stream tick must not end the line, got %q", out)
+	}
+
+	buf.Reset()
+	r(2*1024*1024, 2*1024*1024)
+	out = buf.String()
+	if !strings.Contains(out, "100%") || !strings.HasSuffix(out, "\n") {
+		t.Fatalf("final tick must print 100%% and end the line, got %q", out)
+	}
+
+	buf.Reset()
+	r(2*1024*1024, 2*1024*1024)
+	if buf.Len() != 0 {
+		t.Fatalf("renderer must go quiet after the 100%% line, got %q", buf.String())
+	}
+}
+
+func TestDownloadProgressRendererUnknownTotal(t *testing.T) {
+	var buf bytes.Buffer
+	r := downloadProgressRenderer(&buf, true)
+	r(300*1024, 0)
+	out := buf.String()
+	if !strings.Contains(out, "0.3") || strings.Contains(out, "%") {
+		t.Fatalf("unknown total renders bare MB with no percent, got %q", out)
+	}
+}

--- a/atomic/internal/selfupdate/download_test.go
+++ b/atomic/internal/selfupdate/download_test.go
@@ -1,0 +1,169 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type progressCall struct {
+	received int64
+	total    int64
+}
+
+func TestDownloadEmitsThrottledProgressAndFinalTotal(t *testing.T) {
+	payload := make([]byte, 2*1024*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(payload)))
+		w.Write(payload)
+	}))
+	defer srv.Close()
+
+	var calls []progressCall
+	c := &Client{}
+	dst := filepath.Join(t.TempDir(), "asset")
+	err := c.download(context.Background(), srv.URL, dst, func(received, total int64) {
+		calls = append(calls, progressCall{received, total})
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if len(calls) < 2 {
+		t.Fatalf("expected throttled progress plus final emit, got %d calls", len(calls))
+	}
+	for i := 1; i < len(calls); i++ {
+		if calls[i].received < calls[i-1].received {
+			t.Fatalf("received went backwards at call %d: %+v", i, calls)
+		}
+	}
+	last := calls[len(calls)-1]
+	if last.received != int64(len(payload)) || last.total != int64(len(payload)) {
+		t.Fatalf("final emit should report the full size, got %+v", last)
+	}
+}
+
+func TestDownloadUnknownLengthFinalEmitReportsReceivedAsTotal(t *testing.T) {
+	chunk := make([]byte, 600*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(chunk)
+		w.(http.Flusher).Flush()
+		w.Write(chunk)
+	}))
+	defer srv.Close()
+
+	var calls []progressCall
+	c := &Client{}
+	dst := filepath.Join(t.TempDir(), "asset")
+	err := c.download(context.Background(), srv.URL, dst, func(received, total int64) {
+		calls = append(calls, progressCall{received, total})
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	last := calls[len(calls)-1]
+	want := int64(2 * len(chunk))
+	if last.received != want || last.total != want {
+		t.Fatalf("unknown length: final emit must substitute received for total, got %+v want %d", last, want)
+	}
+}
+
+func TestDownloadStallAborts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1000000")
+		w.Write(make([]byte, 100))
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := &Client{StallTimeout: 50 * time.Millisecond}
+	dst := filepath.Join(t.TempDir(), "asset")
+	start := time.Now()
+	err := c.download(context.Background(), srv.URL, dst, nil)
+	if err == nil {
+		t.Fatal("expected stall error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("error should name the stall, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("stall abort took %s; watchdog is not firing", elapsed)
+	}
+}
+
+// The archive can legitimately take minutes on a slow link, so the download
+// client must have no whole-request Timeout; the stall watchdog governs
+// instead. Lookup keeps its short cap separately.
+func TestDownloadClientHasNoTotalTimeout(t *testing.T) {
+	c := &Client{}
+	if got := c.downloadClient().Timeout; got != 0 {
+		t.Fatalf("download client Timeout = %s, want 0 (stall watchdog governs)", got)
+	}
+	if got := c.httpClient().Timeout; got != lookupTimeout {
+		t.Fatalf("lookup client Timeout = %s, want %s", got, lookupTimeout)
+	}
+}
+
+func TestApplyReportsProgressForArchiveOnly(t *testing.T) {
+	buildDir := t.TempDir()
+	archivePath, sha256sum, err := buildTarGz(buildDir, "fake-binary-content")
+	if err != nil {
+		t.Fatalf("build archive: %v", err)
+	}
+	assetName := filepath.Base(archivePath)
+	checksumPath := buildChecksums(buildDir, assetName, sha256sum)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+assetName, func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, archivePath)
+	})
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, checksumPath)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	binDir := t.TempDir()
+	currentBin := filepath.Join(binDir, "atomic")
+	if err := os.WriteFile(currentBin, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	rel := Release{
+		TagName: "v0.1.1",
+		Assets: []Asset{
+			{Name: assetName, BrowserDownloadURL: srv.URL + "/" + assetName},
+			{Name: "checksums.txt", BrowserDownloadURL: srv.URL + "/checksums.txt"},
+		},
+	}
+
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatalf("stat archive: %v", err)
+	}
+
+	var calls []progressCall
+	c := &Client{
+		DownloadURL: srv.URL,
+		OnProgress: func(received, total int64) {
+			calls = append(calls, progressCall{received, total})
+		},
+	}
+	if err := c.Apply(context.Background(), rel, currentBin); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(calls) == 0 {
+		t.Fatal("Apply emitted no progress for the archive download")
+	}
+	for i, call := range calls {
+		if call.total != info.Size() {
+			t.Fatalf("call %d total = %d, want archive size %d — checksums must not report progress", i, call.total, info.Size())
+		}
+	}
+}

--- a/atomic/internal/selfupdate/selfupdate.go
+++ b/atomic/internal/selfupdate/selfupdate.go
@@ -17,12 +17,19 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 const (
 	defaultBaseURL = "https://api.github.com/repos/damusix/atomic-claude"
 	lookupTimeout  = 10 * time.Second
+
+	// defaultStallTimeout aborts a download only when no bytes arrive for this
+	// long; a slow-but-moving stream never trips it.
+	defaultStallTimeout = 30 * time.Second
+
+	progressEmitBytes = 512 * 1024
 )
 
 // BannerWindow is the minimum interval between repeated update-available
@@ -57,6 +64,14 @@ type Client struct {
 	HTTPClient  *http.Client
 	BaseURL     string // default: defaultBaseURL
 	DownloadURL string // optional override for asset host base URL (tests only)
+
+	// OnProgress, when set, receives byte counts while a release archive
+	// streams down. total is the Content-Length, or equal to received on the
+	// final call when the server sent none. Checksum fetches never report.
+	OnProgress func(received, total int64)
+
+	// StallTimeout overrides the no-data abort window (default 30s).
+	StallTimeout time.Duration
 }
 
 func (c *Client) baseURL() string {
@@ -71,6 +86,16 @@ func (c *Client) httpClient() *http.Client {
 		return c.HTTPClient
 	}
 	return &http.Client{Timeout: lookupTimeout}
+}
+
+// downloadClient has no whole-request Timeout: http.Client.Timeout caps the
+// entire body read, which killed archive downloads on slow links at 10s. The
+// stall watchdog in download governs instead.
+func (c *Client) downloadClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{}
 }
 
 // Lookup fetches the latest GitHub release for channel ("stable" or
@@ -146,12 +171,12 @@ func (c *Client) Apply(ctx context.Context, rel Release, currentBinary string) e
 	defer os.RemoveAll(tmpDir)
 
 	archivePath := filepath.Join(tmpDir, assetName)
-	if err := c.download(ctx, archiveURL, archivePath); err != nil {
+	if err := c.download(ctx, archiveURL, archivePath, c.OnProgress); err != nil {
 		return fmt.Errorf("selfupdate: download archive: %w", err)
 	}
 
 	checksumPath := filepath.Join(tmpDir, checksumName)
-	if err := c.download(ctx, checksumURL, checksumPath); err != nil {
+	if err := c.download(ctx, checksumURL, checksumPath, nil); err != nil {
 		return fmt.Errorf("selfupdate: download checksums: %w", err)
 	}
 
@@ -218,7 +243,7 @@ func (c *Client) ApplyStaged(ctx context.Context, rel Release, stagedPath, curre
 	defer os.RemoveAll(tmpDir)
 
 	checksumPath := filepath.Join(tmpDir, checksumName)
-	if err := c.download(ctx, checksumURL, checksumPath); err != nil {
+	if err := c.download(ctx, checksumURL, checksumPath, nil); err != nil {
 		return fmt.Errorf("selfupdate: download checksums: %w", err)
 	}
 
@@ -320,12 +345,12 @@ func (c *Client) Stage(ctx context.Context, rel Release, stageDir string) (Stage
 	defer os.RemoveAll(tmpDir)
 
 	archivePath := filepath.Join(tmpDir, assetName)
-	if err := c.download(ctx, archiveURL, archivePath); err != nil {
+	if err := c.download(ctx, archiveURL, archivePath, c.OnProgress); err != nil {
 		return StagedInfo{}, fmt.Errorf("selfupdate: download archive: %w", err)
 	}
 
 	checksumPath := filepath.Join(tmpDir, checksumName)
-	if err := c.download(ctx, checksumURL, checksumPath); err != nil {
+	if err := c.download(ctx, checksumURL, checksumPath, nil); err != nil {
 		return StagedInfo{}, fmt.Errorf("selfupdate: download checksums: %w", err)
 	}
 
@@ -361,12 +386,15 @@ func (c *Client) assetURL(rel Release, name string) string {
 	return ""
 }
 
-func (c *Client) download(ctx context.Context, url, dst string) error {
+func (c *Client) download(ctx context.Context, url, dst string, onProgress func(received, total int64)) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
-	resp, err := c.httpClient().Do(req)
+	resp, err := c.downloadClient().Do(req)
 	if err != nil {
 		return err
 	}
@@ -379,8 +407,55 @@ func (c *Client) download(ctx context.Context, url, dst string) error {
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(f, resp.Body)
-	return err
+
+	stall := c.StallTimeout
+	if stall <= 0 {
+		stall = defaultStallTimeout
+	}
+	var stalled atomic.Bool
+	watchdog := time.AfterFunc(stall, func() {
+		stalled.Store(true)
+		cancel()
+	})
+	defer watchdog.Stop()
+
+	total := resp.ContentLength
+	if total < 0 {
+		total = 0
+	}
+	var received, sinceEmit int64
+	buf := make([]byte, 64*1024)
+	for {
+		n, rerr := resp.Body.Read(buf)
+		if n > 0 {
+			watchdog.Reset(stall)
+			if _, werr := f.Write(buf[:n]); werr != nil {
+				return werr
+			}
+			received += int64(n)
+			sinceEmit += int64(n)
+			if onProgress != nil && sinceEmit >= progressEmitBytes {
+				sinceEmit = 0
+				onProgress(received, total)
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			if stalled.Load() {
+				return fmt.Errorf("download stalled: no data for %s", stall)
+			}
+			return rerr
+		}
+	}
+	if onProgress != nil {
+		if total <= 0 {
+			total = received
+		}
+		onProgress(received, total)
+	}
+	return nil
 }
 
 // verifySHA256 checks archivePath against its entry in a checksums file, whose


### PR DESCRIPTION
`atomic update` shared the lookup's 10s whole-request HTTP timeout, and Go's client Timeout caps the entire body read — an archive slower than 10s died mid-stream every time. Downloads now use a client with no total timeout and abort only when no bytes arrive for 30s, mirroring noorm's updater.

While streaming, a TTY gets an in-place `downloading 12.4 / 18.0 MB (68%)` line; redirected output stays silent. Checksum fetches and the release lookup keep their short cap.