### PR TITLE
fix(update): tick download progress every 100ms

### DIFF
--- a/atomic/internal/selfupdate/download_test.go
+++ b/atomic/internal/selfupdate/download_test.go
@@ -18,15 +18,24 @@ type progressCall struct {
 }
 
 func TestDownloadEmitsThrottledProgressAndFinalTotal(t *testing.T) {
-	payload := make([]byte, 2*1024*1024)
+	chunk := make([]byte, 512*1024)
+	const chunks = 4
+	// The throttle is wall-clock, so the server has to pace itself for a
+	// mid-download emit to be possible at all.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Length", fmt.Sprint(len(payload)))
-		w.Write(payload)
+		w.Header().Set("Content-Length", fmt.Sprint(chunks*len(chunk)))
+		for i := 0; i < chunks; i++ {
+			w.Write(chunk)
+			w.(http.Flusher).Flush()
+			time.Sleep(20 * time.Millisecond)
+		}
 	}))
 	defer srv.Close()
 
+	wantSize := int64(chunks * len(chunk))
+
 	var calls []progressCall
-	c := &Client{}
+	c := &Client{ProgressInterval: 10 * time.Millisecond}
 	dst := filepath.Join(t.TempDir(), "asset")
 	err := c.download(context.Background(), srv.URL, dst, func(received, total int64) {
 		calls = append(calls, progressCall{received, total})
@@ -43,7 +52,7 @@ func TestDownloadEmitsThrottledProgressAndFinalTotal(t *testing.T) {
 		}
 	}
 	last := calls[len(calls)-1]
-	if last.received != int64(len(payload)) || last.total != int64(len(payload)) {
+	if last.received != wantSize || last.total != wantSize {
 		t.Fatalf("final emit should report the full size, got %+v", last)
 	}
 }

--- a/atomic/internal/selfupdate/selfupdate.go
+++ b/atomic/internal/selfupdate/selfupdate.go
@@ -29,7 +29,10 @@ const (
 	// long; a slow-but-moving stream never trips it.
 	defaultStallTimeout = 30 * time.Second
 
-	progressEmitBytes = 512 * 1024
+	// progressEmitInterval paces the status line by wall clock rather than by
+	// bytes, so a slow link still shows movement and a fast one does not flood
+	// the terminal with redraws.
+	progressEmitInterval = 100 * time.Millisecond
 
 	// lookupPerPage is GitHub's maximum page size. The default of 30 let a run
 	// of prereleases push the newest stable release off the first page, which
@@ -94,6 +97,9 @@ type Client struct {
 
 	// StallTimeout overrides the no-data abort window (default 30s).
 	StallTimeout time.Duration
+
+	// ProgressInterval overrides how often OnProgress fires (default 100ms).
+	ProgressInterval time.Duration
 }
 
 func (c *Client) baseURL() string {
@@ -505,7 +511,13 @@ func (c *Client) download(ctx context.Context, url, dst string, onProgress func(
 	if total < 0 {
 		total = 0
 	}
-	var received, sinceEmit int64
+	emitEvery := c.ProgressInterval
+	if emitEvery <= 0 {
+		emitEvery = progressEmitInterval
+	}
+
+	var received int64
+	lastEmit := time.Now()
 	buf := make([]byte, 64*1024)
 	for {
 		n, rerr := resp.Body.Read(buf)
@@ -515,9 +527,8 @@ func (c *Client) download(ctx context.Context, url, dst string, onProgress func(
 				return werr
 			}
 			received += int64(n)
-			sinceEmit += int64(n)
-			if onProgress != nil && sinceEmit >= progressEmitBytes {
-				sinceEmit = 0
+			if onProgress != nil && time.Since(lastEmit) >= emitEvery {
+				lastEmit = time.Now()
 				onProgress(received, total)
 			}
 		}

--- a/docs/wiki/config.md
+++ b/docs/wiki/config.md
@@ -204,12 +204,12 @@ Gate 1 is what stops the child re-spawning a grandchild: the child's own invocat
 
 ### Download progress and stall abort
 
-`Client.download` reads the response body in 64KiB chunks and resets a `time.AfterFunc` watchdog on every non-empty read. The watchdog fires only after `StallTimeout` (default `defaultStallTimeout`, 30s) passes with zero bytes, canceling the request's own context, so a slow-but-moving multi-minute transfer never trips it. That watchdog is the reason `downloadClient()` carries no `http.Client.Timeout` at all: the shared `httpClient()` used for `Lookup` keeps the 10s `lookupTimeout`, but that same cap applied to an archive body read used to abort any download slower than 10 seconds outright. Every `progressEmitBytes` (512 KiB) accumulated since the last tick calls `onProgress(received, total)`, and the loop calls it once more after `io.EOF`, substituting `received` for `total` when the server sent no `Content-Length`. Only the archive fetch inside `Client.Apply` and `Client.Stage` forwards `c.OnProgress`; every checksum-file `download` call passes `nil` and never reports.
+`Client.download` reads the response body in 64KiB chunks and resets a `time.AfterFunc` watchdog on every non-empty read. The watchdog fires only after `StallTimeout` (default `defaultStallTimeout`, 30s) passes with zero bytes, canceling the request's own context, so a slow-but-moving multi-minute transfer never trips it. That watchdog is the reason `downloadClient()` carries no `http.Client.Timeout` at all: the shared `httpClient()` used for `Lookup` keeps the 10s `lookupTimeout`, but that same cap applied to an archive body read used to abort any download slower than 10 seconds outright. A read that lands at least `ProgressInterval` (default `progressEmitInterval`, 100ms) after the last tick calls `onProgress(received, total)`, and the loop calls it once more after `io.EOF`, substituting `received` for `total` when the server sent no `Content-Length`. Only the archive fetch inside `Client.Apply` and `Client.Stage` forwards `c.OnProgress`; every checksum-file `download` call passes `nil` and never reports.
 
 ```mermaid
 flowchart TD
     D["Client.download: 64KiB Read loop"] -->|"n>0"| RST["watchdog.Reset(StallTimeout)"]
-    RST --> ACC{"sinceEmit >= progressEmitBytes?"}
+    RST --> ACC{"since last emit >= ProgressInterval?"}
     ACC -->|yes| EM["onProgress(received, total)"]
     ACC -->|no| D
     EM --> D


### PR DESCRIPTION
Download progress was gated on bytes (every 512 KiB), so the status line was paced by throughput: frozen between ticks on a slow link, redrawn hundreds of times a second on a fast one. Now gated on a 100ms wall clock, with `Client.ProgressInterval` as the test override (mirrors the existing `StallTimeout` field).

The throttle test had to start pacing its server — a 2 MiB local transfer completes in under 100ms, so a wall-clock gate would only ever emit the final call.